### PR TITLE
Add/dex-lp-and-swaps

### DIFF
--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_creation_block.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_creation_block.md
@@ -1,0 +1,5 @@
+{% docs eth_dex_creation_block %}
+
+The block number of when this pool was created.
+
+{% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_creation_time.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_creation_time.md
@@ -1,5 +1,5 @@
 {% docs eth_dex_creation_time %}
 
-When this pool was created, where possible.
+The block timestamp of when this pool was created.
 
 {% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_creation_tx.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_creation_tx.md
@@ -1,5 +1,5 @@
 {% docs eth_dex_creation_tx %}
 
-The transaction where this contract was created, where possible.
+The transaction where this contract was created.
 
 {% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_factory_address.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_factory_address.md
@@ -1,5 +1,5 @@
 {% docs eth_dex_factory_address %}
 
-The address that created or deployed this pool, where possible.
+The address that created or deployed this pool, where available.
 
 {% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_lp_decimals.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_lp_decimals.md
@@ -1,0 +1,15 @@
+{% docs eth_dex_lp_decimals %}
+
+The # of decimals for the token included in the liquidity pool, as a JSON object, where available. 
+
+Query example to access the key:value pairing within the object:
+SELECT
+    DISTINCT pool_address AS unique_pools,
+    tokens :token0 :: STRING AS token0,
+    symbols: token0 :: STRING AS token0_symbol,
+    decimals: token0 :: STRING AS token0_decimal
+FROM gnosis.defi.dim_dex_liquidity_pools
+WHERE token0_decimal = 6
+;
+
+{% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_lp_symbols.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_lp_symbols.md
@@ -1,0 +1,15 @@
+{% docs eth_dex_lp_symbols %}
+
+The symbol for the token included in the liquidity pool, as a JSON object, where available. 
+
+Query example to access the key:value pairing within the object:
+SELECT
+    DISTINCT pool_address AS unique_pools,
+    tokens :token0 :: STRING AS token0,
+    symbols: token0 :: STRING AS token0_symbol,
+    decimals: token0 :: STRING AS token0_decimal
+FROM gnosis.defi.dim_dex_liquidity_pools
+WHERE token0_symbol = 'WETH'
+;
+
+{% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_lp_table_doc.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_lp_table_doc.md
@@ -1,5 +1,5 @@
 {% docs eth_dex_lp_table_doc %}
 
-This table contains details on different liquidity pools belonging to sushiswap on the gnosis blockchain
+This table contains details on decentralized exchange (DEX) liquidity pools (LP) on the Gnosis blockchain, including the tokens, symbols and decimals within each pool alongside the following protocols: CURVE, BALANCER, SUSHI, HONEYSWAP, and SWAPR. 
 
 {% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_lp_tokens.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_lp_tokens.md
@@ -1,0 +1,15 @@
+{% docs eth_dex_lp_tokens %}
+
+The address for the token included in the liquidity pool, as a JSON object. 
+
+Query example to access the key:value pairing within the object:
+SELECT
+    DISTINCT pool_address AS unique_pools,
+    tokens :token0 :: STRING AS token0,
+    symbols: token0 :: STRING AS token0_symbol,
+    decimals: token0 :: STRING AS token0_decimal
+FROM gnosis.defi.dim_dex_liquidity_pools
+WHERE token0 = '0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1'
+;
+
+{% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_platform.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_platform.md
@@ -1,5 +1,5 @@
 {% docs eth_dex_platform %}
 
-This field denotes which application the liquidity pool belongs to. 
+The protocol or platform that the liquidity pool belongs to or swap occurred on. 
 
 {% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_pool_name.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_dex_pool_name.md
@@ -1,5 +1,5 @@
 {% docs eth_dex_pool_name %}
 
-The name of the liquidity pool, where possible. 
+The name of the liquidity pool, where available. In some cases, the pool name is a concatenation of symbols or token addresses.
 
 {% enddocs %}

--- a/models/doc_descriptions/dex - (imported from layer 1)/eth_ez_dex_swaps_table_doc.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/eth_ez_dex_swaps_table_doc.md
@@ -1,0 +1,6 @@
+{% docs eth_ez_dex_swaps_table_doc %}
+
+This table currently contains swap events from the ```fact_event_logs``` table for CURVE, BALANCER, SUSHI, HONEYSWAP, and SWAPR along with other helpful columns including an amount USD where possible. Other dexes coming soon! 
+Note: A rule has been put in place to null out the amount_USD if that number is too divergent between amount_in_usd and amount_out_usd. This can happen for swaps of less liquid tokens during very high fluctuation of price.
+
+{% enddocs %}

--- a/models/doc_descriptions/general/__overview__.md
+++ b/models/doc_descriptions/general/__overview__.md
@@ -20,6 +20,7 @@ There is more information on how to use dbt docs in the last section of this doc
 
 **Dimension Tables:**
 - [dim_labels](https://flipsidecrypto.github.io/gnosis-models/#!/model/model.gnosis_models.core__dim_labels)
+- [dim_contracts](https://flipsidecrypto.github.io/gnosis-models/#!/model/model.gnosis_models.core__dim_contracts)
 
 **Fact Tables:**
 - [fact_blocks](https://flipsidecrypto.github.io/gnosis-models/#!/model/model.gnosis_models.core__fact_blocks)
@@ -35,6 +36,9 @@ There is more information on how to use dbt docs in the last section of this doc
 - [ez_token_transfers](https://flipsidecrypto.github.io/gnosis-models/#!/model/model.gnosis_models.core__ez_token_transfers)
 - [ez_decoded_event_logs](https://flipsidecrypto.github.io/gnosis-models/#!/model/model.gnosis_models.core__ez_decoded_event_logs)
 
+### DeFi Tables (gnosis.defi) ###
+- [ez_dex_swaps](https://flipsidecrypto.github.io/gnosis-models/#!/model/model.gnosis_models.defi__ez_dex_swaps)
+- [dim_dex_liquidity_pools](https://flipsidecrypto.github.io/gnosis-models/#!/model/model.gnosis_models.defi__dim_dex_liquidity_pools)
 
 ### NFT Tables (gnosis.nft) ###
 - [ez_nft_transfers](https://flipsidecrypto.github.io/gnosis-models/#!/model/model.gnosis_models.nft__ez_nft_transfers)

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.sql
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.sql
@@ -1,0 +1,27 @@
+{{ config(
+    materialized = 'view',
+    persist_docs ={ "relation": true,
+    "columns": true },
+    meta={
+    'database_tags':{
+        'table': {
+            'PROTOCOL': 'CURVE, FRAXSWAP, KYBERSWAP, PANGOLIN, PLATYPUS, SUSHISWAP, TRADER JOE, UNISWAP',
+            'PURPOSE': 'DEX, LIQUIDITY, POOLS, LP, SWAPS',
+            }
+        }
+    }
+) }}
+
+SELECT
+    block_number AS creation_block,
+    block_timestamp AS creation_time,
+    tx_hash AS creation_tx,
+    platform,
+    contract_address AS factory_address,
+    pool_address,
+    pool_name,
+    tokens,
+    symbols,
+    decimals
+FROM
+    {{ ref('silver_dex__complete_dex_liquidity_pools') }}

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.sql
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.sql
@@ -5,7 +5,7 @@
     meta={
     'database_tags':{
         'table': {
-            'PROTOCOL': 'CURVE, FRAXSWAP, KYBERSWAP, PANGOLIN, PLATYPUS, SUSHISWAP, TRADER JOE, UNISWAP',
+            'PROTOCOL': 'CURVE, BALANCER, SUSHI, HONEYSWAP, SWAPR',
             'PURPOSE': 'DEX, LIQUIDITY, POOLS, LP, SWAPS',
             }
         }

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.yml
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.yml
@@ -1,0 +1,26 @@
+version: 2
+models:
+  - name: defi__dim_dex_liquidity_pools
+    description: '{{ doc("eth_dex_lp_table_doc") }}'
+
+    columns:
+      - name: CREATION_BLOCK
+        description: '{{ doc("eth_dex_creation_block") }}'
+      - name: CREATION_TIME
+        description: '{{ doc("eth_dex_creation_time") }}'
+      - name: CREATION_TX
+        description: '{{ doc("eth_dex_creation_tx") }}'
+      - name: FACTORY_ADDRESS
+        description: '{{ doc("eth_dex_factory_address") }}'
+      - name: PLATFORM
+        description: '{{ doc("eth_dex_platform") }}'
+      - name: POOL_ADDRESS
+        description: '{{ doc("eth_dex_pool_address") }}'
+      - name: POOL_NAME
+        description: '{{ doc("eth_dex_pool_name") }}'
+      - name: TOKENS
+        description: '{{ doc("eth_dex_lp_tokens") }}'
+      - name: SYMBOLS
+        description: '{{ doc("eth_dex_lp_symbols") }}'
+      - name: DECIMALS
+        description: '{{ doc("eth_dex_lp_decimals") }}'

--- a/models/gold/defi/defi__ez_dex_swaps.sql
+++ b/models/gold/defi/defi__ez_dex_swaps.sql
@@ -1,0 +1,38 @@
+{{ config(
+    materialized = 'view',
+    persist_docs ={ "relation": true,
+    "columns": true },
+    meta={
+        'database_tags':{
+            'table': {
+                'PROTOCOL': 'CURVE, BALANCER, SUSHI, HONEYSWAP, SWAPR',
+                'PURPOSE': 'DEX, SWAPS'
+            }
+        }
+    }
+) }}
+
+SELECT
+  block_number,
+  block_timestamp,
+  tx_hash,
+  origin_function_signature,
+  origin_from_address,
+  origin_to_address,
+  contract_address,
+  pool_name,
+  event_name,
+  amount_in,
+  amount_in_usd,
+  amount_out,
+  amount_out_usd,
+  sender,
+  tx_to,
+  event_index,
+  platform,
+  token_in,
+  token_out,
+  symbol_in,
+  symbol_out,
+  _log_id
+FROM {{ ref('silver_dex__complete_dex_swaps') }}

--- a/models/gold/defi/defi__ez_dex_swaps.yml
+++ b/models/gold/defi/defi__ez_dex_swaps.yml
@@ -1,0 +1,48 @@
+version: 2
+models:
+  - name: defi__ez_dex_swaps
+    description: '{{ doc("eth_ez_dex_swaps_table_doc") }}'
+
+    columns:
+      - name: BLOCK_NUMBER
+        description: '{{ doc("gno_block_number") }}'
+      - name: BLOCK_TIMESTAMP
+        description: '{{ doc("gno_block_timestamp") }}'
+      - name: TX_HASH
+        description: '{{ doc("gno_logs_tx_hash") }}'
+      - name: CONTRACT_ADDRESS
+        description: '{{ doc("gno_logs_contract_address") }}'
+      - name: EVENT_NAME
+        description: '{{ doc("gno_event_name") }}'
+      - name: AMOUNT_IN
+        description: '{{ doc("eth_dex_swaps_amount_in") }}'
+      - name: AMOUNT_OUT
+        description: '{{ doc("eth_dex_swaps_amount_out") }}'
+      - name: AMOUNT_IN_USD
+        description: '{{ doc("eth_dex_swaps_amount_in_usd") }}'
+      - name: AMOUNT_OUT_USD
+        description: '{{ doc("eth_dex_swaps_amount_out_usd") }}'
+      - name: TOKEN_IN
+        description: '{{ doc("eth_dex_swaps_token_in") }}'
+      - name: TOKEN_OUT
+        description: '{{ doc("eth_dex_swaps_token_out") }}'
+      - name: SYMBOL_IN
+        description: '{{ doc("eth_dex_swaps_symbol_in") }}'
+      - name: SYMBOL_OUT
+        description: '{{ doc("eth_dex_swaps_symbol_out") }}'
+      - name: SENDER
+        description: '{{ doc("eth_dex_swaps_sender") }}'
+      - name: TX_TO
+        description: '{{ doc("eth_dex_swaps_tx_to") }}'
+      - name: PLATFORM
+        description: '{{ doc("eth_dex_platform") }}'
+      - name: EVENT_INDEX
+        description: '{{ doc("gno_event_index") }}'
+      - name: _LOG_ID
+        description: '{{ doc("gno_log_id_events") }}'
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        description: '{{ doc("gno_tx_origin_sig") }}'
+      - name: ORIGIN_FROM_ADDRESS
+        description: '{{ doc("gno_origin_from") }}'
+      - name: ORIGIN_TO_ADDRESS
+        description: '{{ doc("gno_origin_to") }}'

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -1,0 +1,219 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address",
+    tags = ['non_realtime']
+) }}
+
+--    full_refresh = false
+
+WITH pools_registered AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        event_index,
+        tx_hash,
+        contract_address,
+        topics [1] :: STRING AS pool_id,
+        SUBSTR(topics [1] :: STRING,1,42) AS pool_address,
+        _log_id,
+        _inserted_timestamp,
+        ROW_NUMBER() OVER (ORDER BY pool_address) AS row_num
+    FROM
+        {{ ref('silver__logs') }}
+    WHERE
+        topics[0]::STRING = '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e' --PoolRegistered
+        AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 2
+    FROM
+        {{ this }}
+)
+{% endif %}
+
+),
+
+tokens_registered AS (
+
+SELECT
+    block_number,
+    block_timestamp,
+    event_index,
+    tx_hash,
+    contract_address,
+    decoded_flat :poolId :: STRING AS pool_id,
+    decoded_flat :tokens AS tokens,
+    tokens[0] :: STRING AS token0,
+    tokens[1] :: STRING AS token1,
+    tokens[2] :: STRING AS token2,
+    tokens[3] :: STRING AS token3,
+    tokens[4] :: STRING AS token4,
+    tokens[5] :: STRING AS token5,
+    tokens[6] :: STRING AS token6,
+    tokens[7] :: STRING AS token7,
+    decoded_flat :assetManagers AS asset_managers,
+    _log_id,
+    _inserted_timestamp
+FROM {{ ref('silver__decoded_logs') }}
+WHERE
+    topics[0]::STRING = '0xf5847d3f2197b16cdcd2098ec95d0905cd1abdaf415f07bb7cef2bba8ac5dec4' --TokensRegistered
+    AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'
+    AND tx_hash IN (
+        SELECT
+            tx_hash
+        FROM
+            pools_registered
+    )
+),
+
+function_sigs AS (
+
+SELECT
+    '0x06fdde03' AS function_sig, 
+    'name' AS function_name
+UNION ALL
+SELECT
+    '0x95d89b41' AS function_sig, 
+    'symbol' AS function_name
+UNION ALL
+SELECT
+    '0x313ce567' AS function_sig, 
+    'decimals' AS function_name
+),
+
+inputs_pools AS (
+
+SELECT
+    pool_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY pool_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM pools_registered
+JOIN function_sigs ON 1=1 
+),
+
+pool_token_reads AS (
+
+{% for item in range(50) %}
+(
+SELECT
+    ethereum.streamline.udf_json_rpc_read_calls(
+        node_url,
+        headers,
+        PARSE_JSON(batch_read)
+    ) AS read_output,
+    SYSDATE() AS _inserted_timestamp
+FROM (
+    SELECT
+        CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+    FROM (
+        SELECT 
+            pool_address,
+            block_number,
+            function_sig,
+            function_input,
+            CONCAT(
+                '[\'',
+                pool_address,
+                '\',',
+                block_number,
+                ',\'',
+                function_sig,
+                '\',\'',
+                function_input,
+                '\']'
+                ) AS read_input,
+                row_num
+        FROM inputs_pools
+        LEFT JOIN pools_registered USING(pool_address) 
+            ) ready_reads_pools
+    WHERE row_num BETWEEN {{ item * 50 + 1 }} AND {{ (item + 1) * 50}}
+    ) batch_reads_pools
+JOIN {{ source(
+            'streamline_crosschain',
+            'node_mapping'
+        ) }} ON 1=1 
+    AND chain = 'gnosis'
+) {% if not loop.last %}
+UNION ALL
+{% endif %}
+{% endfor %}
+),
+
+reads_adjusted AS (
+    
+SELECT
+        VALUE :id :: STRING AS read_id,
+        VALUE :result :: STRING AS read_result,
+        SPLIT(
+            read_id,
+            '-'
+        ) AS read_id_object,
+        read_id_object [0] :: STRING AS pool_address,
+        read_id_object [1] :: STRING AS block_number,
+        read_id_object [2] :: STRING AS function_sig,
+        read_id_object [3] :: STRING AS function_input,
+        _inserted_timestamp
+FROM
+    pool_token_reads,
+    LATERAL FLATTEN(
+        input => read_output [0] :data
+    ) 
+),
+
+pool_details AS (
+
+SELECT
+    pool_address,
+    function_sig,
+    function_name,
+    read_result,
+    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
+    _inserted_timestamp
+FROM reads_adjusted
+LEFT JOIN function_sigs USING(function_sig)
+    ),
+
+FINAL AS (
+SELECT
+    pool_address,
+    MIN(CASE WHEN function_name = 'symbol' THEN utils.udf_hex_to_string(segmented_output [2] :: STRING) END) AS pool_symbol,
+    MIN(CASE WHEN function_name = 'name' THEN utils.udf_hex_to_string(segmented_output [2] :: STRING) END) AS pool_name,
+    MIN(CASE 
+            WHEN read_result::STRING = '0x' THEN NULL
+            ELSE utils.udf_hex_to_int(LEFT(read_result::STRING,66))
+        END)::INTEGER  AS pool_decimals,
+    MAX(_inserted_timestamp) AS _inserted_timestamp
+FROM pool_details
+GROUP BY 1
+)
+
+SELECT
+    p.block_number,
+    p.block_timestamp,
+    p.event_index,
+    p.tx_hash,
+    p.contract_address,
+    p.pool_id,
+    f.pool_address,
+    f.pool_symbol,
+    f.pool_name,
+    f.pool_decimals,
+    t.token0,
+    t.token1,
+    t.token2,
+    t.token3,
+    t.token4,
+    t.token5,
+    t.token6,
+    t.token7,
+    t.asset_managers,
+    p._log_id,
+    f._inserted_timestamp
+FROM FINAL f
+LEFT JOIN pools_registered p ON f.pool_address = p.pool_address
+LEFT JOIN tokens_registered t ON p.pool_id = t.pool_id
+WHERE t.token0 IS NOT NULL

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.yml
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.yml
@@ -1,0 +1,12 @@
+version: 2
+models:
+  - name: silver_dex__balancer_pools
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    
+      
+      
+ 

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -1,0 +1,90 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['non_realtime']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_name,
+        pool_address
+    FROM
+        {{ ref('silver_dex__balancer_pools') }}
+),
+swaps_base AS (
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        'Swap' AS event_name,
+        event_index,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            )
+        ) AS amount_in_unadj,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            )
+        ) AS amount_out_unadj,
+        topics [1] :: STRING AS pool_id,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token_in,
+        CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS token_out,
+        SUBSTR(
+            topics [1] :: STRING,
+            1,
+            42
+        ) AS pool_address,
+        _log_id,
+        _inserted_timestamp,
+        'balancer' AS platform,
+        origin_from_address AS sender,
+        origin_from_address AS tx_to
+    FROM
+        {{ ref('silver__logs') }}
+    WHERE
+        topics [0] :: STRING = '0x2170c741c41531aec20e7c107c24eecfdd15e69c9bb0a8dd37b1840b9e0b207b'
+        AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    amount_in_unadj,
+    amount_out_unadj,
+    token_in,
+    token_out,
+    sender,
+    tx_to,
+    pool_id,
+    s.pool_address AS contract_address,
+    pool_name,
+    event_name,
+    platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base s
+    INNER JOIN pools p
+    ON p.pool_address = s.pool_address

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.yml
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.yml
@@ -1,0 +1,66 @@
+version: 2
+models:
+  - name: silver_dex__balancer_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _log_id
+    columns:
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: POOL_NAME
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar
+      - name: SENDER
+        tests:
+          - not_null
+      - name: TX_TO
+        tests:
+          - not_null
+      - name: TX_HASH
+        tests:
+          - not_null

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -1,0 +1,347 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_id",
+    tags = ['non_realtime']
+) }}
+--    full_refresh = false,
+
+WITH contract_deployments AS (
+
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    from_address AS deployer_address,
+    to_address AS contract_address,
+    _call_id,
+    _inserted_timestamp,
+    ROW_NUMBER() OVER (ORDER BY contract_address) AS row_num
+FROM
+    {{ ref('silver__traces' )}}
+WHERE 
+    -- curve contract deployers
+    from_address IN (
+        '0x7eeac6cddbd1d0b8af061742d41877d7f707289a',
+        '0xcbaf0a32f5a16b326f00607421857f68fc72e508',
+        '0xd25fcbb7b6021cf83122fcd65be88a045d5f961c',
+        '0xd19baeadc667cf2015e395f2b08668ef120f41f5'
+        )
+    AND TYPE ilike 'create%'
+    AND TX_STATUS ilike 'success'
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 3
+    FROM
+        {{ this }}
+)
+AND to_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+QUALIFY(ROW_NUMBER() OVER(PARTITION BY to_address ORDER BY block_timestamp ASC)) = 1
+),
+
+function_sigs AS (
+
+SELECT
+	'0x87cb4f57' AS function_sig,
+    'base_coins' AS function_name
+UNION ALL
+SELECT
+	'0xb9947eb0' AS function_sig,
+    'underlying_coins' AS function_name
+UNION ALL
+SELECT
+    '0xc6610657' AS function_sig, 
+    'coins' AS function_name
+UNION ALL
+SELECT
+    '0x06fdde03' AS function_sig, 
+    'name' AS function_name
+UNION ALL
+SELECT
+    '0x95d89b41' AS function_sig, 
+    'symbol' AS function_name
+UNION ALL
+SELECT
+    '0x313ce567' AS function_sig, 
+    'decimals' AS function_name
+),
+
+function_inputs AS (
+    SELECT
+        SEQ4() AS function_input
+    FROM
+        TABLE(GENERATOR(rowcount => 8))
+),
+
+inputs_coins AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'coins'
+),
+
+inputs_base_coins AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'base_coins'
+),
+
+inputs_underlying_coins AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'underlying_coins'
+),
+
+inputs_pool_details AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    NULL AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+WHERE function_name IN ('name','symbol','decimals')
+),
+
+all_inputs AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_base_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_underlying_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_pool_details
+),
+
+pool_token_reads AS (
+
+{% for item in range(20) %}
+(
+SELECT
+    ethereum.streamline.udf_json_rpc_read_calls(
+        node_url,
+        headers,
+        PARSE_JSON(batch_read)
+    ) AS read_output,
+    SYSDATE() AS _inserted_timestamp
+FROM (
+    SELECT
+        CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+    FROM (
+        SELECT 
+            deployer_address,
+            contract_address,
+            block_number,
+            function_sig,
+            function_input,
+            CONCAT(
+                '[\'',
+                contract_address,
+                '\',',
+                block_number,
+                ',\'',
+                function_sig,
+                '\',\'',
+                (CASE WHEN function_input IS NULL THEN '' ELSE function_input::STRING END),
+                '\']'
+                ) AS read_input,
+                row_num
+        FROM all_inputs
+        LEFT JOIN contract_deployments USING(contract_address) 
+            ) ready_reads_pools
+    WHERE row_num BETWEEN {{ item * 50 + 1 }} AND {{ (item + 1) * 50}}
+    ) batch_reads_pools
+JOIN {{ source(
+            'streamline_crosschain',
+            'node_mapping'
+        ) }} ON 1=1 
+    AND chain = 'gnosis'
+) {% if not loop.last %}
+UNION ALL
+{% endif %}
+{% endfor %}
+),
+
+reads_adjusted AS (
+    
+SELECT
+        VALUE :id :: STRING AS read_id,
+        VALUE :result :: STRING AS read_result,
+        SPLIT(
+            read_id,
+            '-'
+        ) AS read_id_object,
+        read_id_object [0] :: STRING AS contract_address,
+        read_id_object [1] :: STRING AS block_number,
+        read_id_object [2] :: STRING AS function_sig,
+        read_id_object [3] :: STRING AS function_input,
+        _inserted_timestamp
+FROM
+    pool_token_reads,
+    LATERAL FLATTEN(
+        input => read_output [0] :data
+    ) 
+),
+
+tokens AS (
+    
+SELECT
+    contract_address,
+    function_sig,
+    function_name,
+    function_input,
+    read_result,
+    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}')[0]AS segmented_token_address,
+    _inserted_timestamp
+FROM reads_adjusted
+LEFT JOIN function_sigs USING(function_sig)
+WHERE function_name IN ('coins','base_coins','underlying_coins')
+    AND read_result IS NOT NULL
+    
+),
+
+pool_details AS (
+
+SELECT
+    contract_address,
+    function_sig,
+    function_name,
+    function_input,
+    read_result,
+    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
+    _inserted_timestamp
+FROM reads_adjusted
+LEFT JOIN function_sigs USING(function_sig)
+WHERE function_name IN ('name','symbol','decimals')
+    AND read_result IS NOT NULL
+
+),
+
+all_pools AS (
+SELECT
+    t.contract_address AS pool_address,
+    CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)) AS token_address,
+    function_input AS token_id,
+    function_name AS token_type,
+    MIN(CASE WHEN p.function_name = 'symbol' THEN utils.udf_hex_to_string(RTRIM(p.segmented_output [2] :: STRING, 0)) END) AS pool_symbol,
+    MIN(CASE WHEN p.function_name = 'name' THEN CONCAT(utils.udf_hex_to_string(p.segmented_output [2] :: STRING),
+        utils.udf_hex_to_string(segmented_output [3] :: STRING)) END) AS pool_name,
+    MIN(CASE 
+            WHEN p.read_result::STRING = '0x' THEN NULL
+            ELSE utils.udf_hex_to_int(LEFT(p.read_result::STRING,66))
+        END)::INTEGER  AS pool_decimals,
+    CONCAT(
+        t.contract_address,
+        '-',
+        CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)),
+        '-',
+        function_input,
+        '-',
+        function_name
+    ) AS pool_id,
+    MAX(t._inserted_timestamp) AS _inserted_timestamp
+FROM tokens t
+LEFT JOIN pool_details p USING(contract_address)
+WHERE token_address IS NOT NULL 
+    AND token_address <> '0x0000000000000000000000000000000000000000'
+GROUP BY 1,2,3,4
+),
+
+FINAL AS (
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    deployer_address,
+    pool_address,
+    CASE
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d'
+        ELSE token_address
+    END AS token_address,
+    token_id,
+    token_type,
+    CASE 
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 'WXDAI'
+        WHEN pool_symbol IS NULL THEN c.token_symbol
+        ELSE pool_symbol
+    END AS pool_symbol,
+    pool_name,
+    CASE 
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '18'
+    	WHEN pool_decimals IS NULL THEN c.token_decimals
+        ELSE pool_decimals
+    END AS pool_decimals,
+    pool_id,
+    _call_id,
+    a._inserted_timestamp
+FROM all_pools a
+LEFT JOIN {{ ref('silver__contracts') }} c 
+    ON a.token_address = c.contract_address
+LEFT JOIN contract_deployments d 
+    ON a.pool_address = d.contract_address
+QUALIFY(ROW_NUMBER() OVER(PARTITION BY pool_address, token_address ORDER BY a._inserted_timestamp DESC)) = 1
+)
+
+SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY pool_address ORDER BY token_address ASC) AS token_num
+FROM FINAL

--- a/models/silver/dex/curve/silver_dex__curve_pools.yml
+++ b/models/silver/dex/curve/silver_dex__curve_pools.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: silver_dex__curve_pools
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ID
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar
+      - name: TOKEN_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar
+      - name: POOL_SYMBOL
+      - name: POOL_NAME
+      - name: POOL_DECIMALS
+      - name: _INSERTED_TIMESTAMP

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -1,0 +1,215 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "_log_id",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['non_realtime']
+) }}
+
+WITH pool_meta AS (
+
+    SELECT
+        DISTINCT pool_address,
+        pool_name,
+        token_address,
+        pool_symbol AS symbol,
+        token_id::INTEGER AS token_id,
+        token_type::STRING AS token_type
+    FROM
+        {{ ref('silver_dex__curve_pools') }}
+),
+
+pools AS (
+    SELECT 
+        DISTINCT pool_address,
+        pool_name
+    FROM pool_meta
+    QUALIFY (ROW_NUMBER() OVER (PARTITION BY pool_address ORDER BY pool_name ASC NULLS LAST)) = 1
+),
+
+curve_base AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        event_index,
+        CASE
+            WHEN topics [0] :: STRING = '0xd013ca23e77a65003c2c659c5442c00c805371b7fc1ebd4c206c41d1536bd90b' THEN 'TokenExchangeUnderlying'
+            ELSE 'TokenExchange'
+        END AS event_name,
+        contract_address AS pool_address,
+        pool_name,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
+            segmented_data [0] :: STRING
+        )) AS sold_id,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        )) AS tokens_sold,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
+            segmented_data [2] :: STRING
+        )) AS bought_id,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
+            segmented_data [3] :: STRING
+        )) AS tokens_bought,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }} l
+        INNER JOIN pools p
+        ON p.pool_address = l.contract_address
+    WHERE
+        topics [0] :: STRING IN (
+            '0x8b3e96f2b889fa771c53c981b40daf005f63f637f1869f707052d15a3dd97140', --TokenExchange
+            '0xb2e76ae99761dc136e598d4a629bb347eccb9532a5f8bbd72e18467c3c34cc98', --TokenExchange
+            '0xd013ca23e77a65003c2c659c5442c00c805371b7fc1ebd4c206c41d1536bd90b' --TokenExchangeUnderlying
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+
+token_exchange AS (
+
+SELECT
+	_log_id,
+    MAX(CASE WHEN sold_id = token_id THEN token_address END) AS token_in,
+    MAX(CASE WHEN bought_id = token_id THEN token_address END) AS token_out,
+    MAX(CASE WHEN sold_id = token_id THEN symbol END) AS symbol_in,
+    MAX(CASE WHEN bought_id = token_id THEN symbol END) AS symbol_out
+FROM curve_base t
+LEFT JOIN pool_meta p ON p.pool_address = t.pool_address AND (p.token_id = t.sold_id OR p.token_id = t.bought_id)
+WHERE token_type = 'coins'
+GROUP BY 1
+),
+
+token_transfers AS (
+    SELECT
+        tx_hash,
+        contract_address AS token_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                DATA :: STRING
+            )
+        ) AS amount,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address
+    FROM
+        {{ ref('silver__logs') }}
+    WHERE
+        topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+        AND tx_hash IN (
+            SELECT
+                DISTINCT tx_hash
+            FROM
+                curve_base
+        )
+        AND CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) <> '0x0000000000000000000000000000000000000000'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+from_transfers AS (
+    SELECT
+        DISTINCT tx_hash,
+        token_address,
+        from_address,
+        amount
+    FROM
+        token_transfers
+),
+to_transfers AS (
+    SELECT
+        DISTINCT tx_hash,
+        token_address,
+        to_address,
+        amount
+    FROM
+        token_transfers
+),
+
+ready_pool_info AS (
+
+SELECT
+	s.block_number,
+    s.block_timestamp,
+    s.tx_hash,
+    s.origin_function_signature,
+    s.origin_from_address,
+    s.origin_from_address AS tx_to,
+    s.origin_to_address,
+    event_index,
+    event_name,
+    pool_address,
+    pool_address AS contract_address,
+    pool_name,
+    sender,
+    sold_id,
+    tokens_sold,
+    COALESCE(sold.token_address,e.token_in) AS token_in,
+    e.symbol_in AS symbol_in,
+    bought_id,
+    tokens_bought,
+    COALESCE(bought.token_address,e.token_out) AS token_out,
+    e.symbol_out AS symbol_out,
+    s._log_id,
+    _inserted_timestamp
+FROM
+    curve_base s
+    LEFT JOIN token_exchange e ON s._log_id = e._log_id
+    LEFT JOIN from_transfers sold
+    ON tokens_sold = sold.amount
+    AND s.tx_hash = sold.tx_hash
+    LEFT JOIN to_transfers bought
+    ON tokens_bought = bought.amount
+    AND s.tx_hash = bought.tx_hash
+WHERE
+	tokens_sold <> 0
+qualify(ROW_NUMBER() over(PARTITION BY s._log_id
+    ORDER BY
+        _inserted_timestamp DESC)) = 1  
+)
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    tx_to,
+    origin_to_address,
+    event_index,
+    event_name,
+    pool_address,
+    contract_address,
+    pool_name,
+    sender,
+    sold_id,
+    tokens_sold,
+    token_in,
+    symbol_in,
+    bought_id,
+    tokens_bought,
+    token_out,
+    symbol_out,
+    _log_id,
+    _inserted_timestamp,
+    'curve' AS platform
+FROM
+    ready_pool_info

--- a/models/silver/dex/curve/silver_dex__curve_swaps.yml
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.yml
@@ -1,0 +1,54 @@
+version: 2
+models:
+  - name: silver_dex__curve_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _log_id
+    columns:
+      - name: TOKENS_SOLD
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: TOKENS_BOUGHT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: POOL_NAME
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar
+      - name: SENDER
+        tests:
+          - not_null
+      - name: TX_TO
+        tests:
+          - not_null
+      - name: TOKEN_IN
+      - name: TOKEN_OUT
+      - name: TX_HASH
+        tests:
+          - not_null

--- a/models/silver/dex/honeyswap/silver_dex__honeyswap_pools.sql
+++ b/models/silver/dex/honeyswap/silver_dex__honeyswap_pools.sql
@@ -1,0 +1,58 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address",
+    tags = ['non_realtime']
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        ethereum.public.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) :: INT AS pool_id,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs') }}
+    WHERE
+        contract_address = LOWER('0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7')
+        AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    contract_address,
+    token0,
+    token1,
+    pool_address,
+    pool_id,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/honeyswap/silver_dex__honeyswap_pools.yml
+++ b/models/silver/dex/honeyswap/silver_dex__honeyswap_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__honeyswap_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+                - TIMESTAMP_LTZ

--- a/models/silver/dex/honeyswap/silver_dex__honeyswap_swaps.sql
+++ b/models/silver/dex/honeyswap/silver_dex__honeyswap_swaps.sql
@@ -1,0 +1,117 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['non_realtime']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__honeyswap_pools') }}
+),
+swaps_base AS (
+    SELECT
+        block_number,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            ) :: INTEGER
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            ) :: INTEGER
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            ) :: INTEGER
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [3] :: STRING
+            ) :: INTEGER
+        ) AS amount1Out,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tx_to,
+        token0,
+        token1,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }}
+        INNER JOIN pools p
+        ON p.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    contract_address,
+    sender,
+    tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Swap' AS event_name,
+    'honeyswap' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/honeyswap/silver_dex__honeyswap_swaps.yml
+++ b/models/silver/dex/honeyswap/silver_dex__honeyswap_swaps.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: silver_dex__honeyswap_swaps
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+                - TIMESTAMP_LTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -1,0 +1,272 @@
+{{ config(
+  materialized = 'incremental',
+  unique_key = "_id",
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['non_realtime']
+) }}
+
+WITH contracts AS (
+
+  SELECT
+    contract_address AS address,
+    token_symbol AS symbol,
+    token_decimals AS decimals,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver__contracts') }}
+),
+
+balancer AS (
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    pool_address,
+    pool_name,
+    'balancer' AS platform,
+    _log_id AS _id,
+    _inserted_timestamp,
+    token0,
+    token1,
+    token2,
+    token3,
+    token4,
+    token5,
+    token6,
+    token7
+FROM
+    {{ ref('silver_dex__balancer_pools') }}
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+
+curve AS (
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    deployer_address AS contract_address,
+    pool_address,
+    pool_name,
+    'curve' AS platform,
+    _call_id AS _id,
+    _inserted_timestamp,
+    MAX(CASE WHEN token_num = 1 THEN token_address END) AS token0,
+    MAX(CASE WHEN token_num = 2 THEN token_address END) AS token1,
+    MAX(CASE WHEN token_num = 3 THEN token_address END) AS token2,
+    MAX(CASE WHEN token_num = 4 THEN token_address END) AS token3,
+    MAX(CASE WHEN token_num = 5 THEN token_address END) AS token4,
+    MAX(CASE WHEN token_num = 6 THEN token_address END) AS token5,
+    MAX(CASE WHEN token_num = 7 THEN token_address END) AS token6,
+    MAX(CASE WHEN token_num = 8 THEN token_address END) AS token7
+FROM
+    {{ ref('silver_dex__curve_pools') }}
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+GROUP BY all
+),
+
+honeyswap AS (
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    pool_address,
+    NULL AS pool_name,
+    token0,
+    token1,
+    'honeyswap' AS platform,
+    _log_id AS _id,
+    _inserted_timestamp
+FROM
+    {{ ref('silver_dex__honeyswap_pools') }}
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+
+swapr AS (
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    pool_address,
+    NULL AS pool_name,
+    token0,
+    token1,
+    'swapr' AS platform,
+    _log_id AS _id,
+    _inserted_timestamp
+FROM
+    {{ ref('silver_dex__swapr_pools') }}
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+
+sushi AS (
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    pool_address,
+    NULL AS pool_name,
+    token0,
+    token1,
+    'sushiswap' AS platform,
+    _log_id AS _id,
+    _inserted_timestamp
+FROM
+    {{ ref('silver_dex__sushi_pools') }}
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+
+all_pools_standard AS (
+    SELECT *
+    FROM honeyswap
+    UNION ALL
+    SELECT *
+    FROM swapr
+    UNION ALL
+    SELECT *
+    FROM sushi
+),
+
+all_pools_other AS (
+    SELECT *
+    FROM balancer
+    UNION ALL
+    SELECT *
+    FROM curve
+),
+
+FINAL AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        contract_address,
+        pool_address,
+        CASE
+          WHEN pool_name IS NULL 
+            THEN CONCAT(  
+                    COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),
+                    '-',
+                    COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42)))
+                  ) 
+          ELSE pool_name
+        END AS pool_name,
+        OBJECT_CONSTRUCT('token0',token0,'token1',token1) AS tokens,
+        OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
+        OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
+        platform,
+        _id,
+        p._inserted_timestamp
+    FROM all_pools_standard p 
+    LEFT JOIN contracts c0
+        ON c0.address = p.token0
+    LEFT JOIN contracts c1
+        ON c1.address = p.token1
+    UNION ALL
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        contract_address,
+        pool_address,
+        CASE 
+          WHEN pool_name IS NULL 
+            THEN CONCAT(
+                  COALESCE(c0.symbol, SUBSTRING(token0, 1, 5) || '...' || SUBSTRING(token0, 39, 42)),
+                  CASE WHEN token1 IS NOT NULL THEN '-' || COALESCE(c1.symbol, SUBSTRING(token1, 1, 5) || '...' || SUBSTRING(token1, 39, 42)) ELSE '' END,
+                  CASE WHEN token2 IS NOT NULL THEN '-' || COALESCE(c2.symbol, SUBSTRING(token2, 1, 5) || '...' || SUBSTRING(token2, 39, 42)) ELSE '' END,
+                  CASE WHEN token3 IS NOT NULL THEN '-' || COALESCE(c3.symbol, SUBSTRING(token3, 1, 5) || '...' || SUBSTRING(token3, 39, 42)) ELSE '' END,
+                  CASE WHEN token4 IS NOT NULL THEN '-' || COALESCE(c4.symbol, SUBSTRING(token4, 1, 5) || '...' || SUBSTRING(token4, 39, 42)) ELSE '' END,
+                  CASE WHEN token5 IS NOT NULL THEN '-' || COALESCE(c5.symbol, SUBSTRING(token5, 1, 5) || '...' || SUBSTRING(token5, 39, 42)) ELSE '' END,
+                  CASE WHEN token6 IS NOT NULL THEN '-' || COALESCE(c6.symbol, SUBSTRING(token6, 1, 5) || '...' || SUBSTRING(token6, 39, 42)) ELSE '' END,
+                  CASE WHEN token7 IS NOT NULL THEN '-' || COALESCE(c7.symbol, SUBSTRING(token7, 1, 5) || '...' || SUBSTRING(token7, 39, 42)) ELSE '' END
+              ) 
+            ELSE pool_name
+        END AS pool_name,
+        OBJECT_CONSTRUCT('token0', token0, 'token1', token1, 'token2', token2, 'token3', token3, 'token4', token4, 'token5', token5, 'token6', token6, 'token7', token7) AS tokens,
+        OBJECT_CONSTRUCT('token0', c0.symbol, 'token1', c1.symbol, 'token2', c2.symbol, 'token3', c3.symbol, 'token4', c4.symbol, 'token5', c5.symbol, 'token6', c6.symbol, 'token7', c7.symbol) AS symbols,
+        OBJECT_CONSTRUCT('token0', c0.decimals, 'token1', c1.decimals, 'token2', c2.decimals, 'token3', c3.decimals, 'token4', c4.decimals, 'token5', c5.decimals, 'token6', c6.decimals, 'token7', c7.decimals) AS decimals,
+        platform,
+        _id,
+        p._inserted_timestamp
+    FROM all_pools_other p
+    LEFT JOIN contracts c0
+        ON c0.address = p.token0
+    LEFT JOIN contracts c1
+        ON c1.address = p.token1
+    LEFT JOIN contracts c2
+        ON c2.address = p.token2
+    LEFT JOIN contracts c3
+        ON c3.address = p.token3
+    LEFT JOIN contracts c4
+        ON c4.address = p.token4
+    LEFT JOIN contracts c5
+        ON c5.address = p.token5
+    LEFT JOIN contracts c6
+        ON c6.address = p.token6
+    LEFT JOIN contracts c7
+        ON c7.address = p.token7
+)
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    platform,
+    contract_address,
+    pool_address,
+    pool_name,
+    tokens,
+    symbols,
+    decimals,
+    _id,
+    _inserted_timestamp
+FROM FINAL 

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.yml
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.yml
@@ -1,0 +1,44 @@
+version: 2
+models:
+  - name: silver_dex__complete_dex_liquidity_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: _ID
+        tests:
+          - not_null

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -1,0 +1,557 @@
+{{ config(
+  materialized = 'incremental',
+  unique_key = "_log_id",
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['non_realtime']
+) }}
+
+WITH contracts AS (
+
+  SELECT
+    contract_address AS address,
+    token_symbol AS symbol,
+    token_name AS NAME,
+    token_decimals AS decimals
+  FROM
+    {{ ref('silver__contracts') }}
+),
+prices AS (
+  SELECT
+    HOUR,
+    token_address,
+    price
+  FROM
+    {{ ref('core__fact_hourly_token_prices') }}
+  WHERE
+    token_address IN (
+      SELECT
+        DISTINCT address
+      FROM
+        contracts
+    )
+
+{% if is_incremental() %}
+AND HOUR >= (
+  SELECT
+    MAX(_inserted_timestamp) :: DATE - 2
+  FROM
+    {{ this }}
+)
+{% endif %}
+),
+sushi_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    NULL AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__sushi_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+curve_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    s.tokens_sold AS amount_in_unadj,
+    s.tokens_bought AS amount_out_unadj,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    COALESCE(
+      c1.symbol,
+      s.symbol_in
+    ) AS token_symbol_in,
+    COALESCE(
+      c2.symbol,
+      s.symbol_out
+    ) AS token_symbol_out,
+    NULL AS pool_name,
+    c1.decimals AS decimals_in,
+    CASE
+      WHEN decimals_in IS NOT NULL THEN s.tokens_sold / pow(
+        10,
+        decimals_in
+      )
+      ELSE s.tokens_sold
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    CASE
+      WHEN decimals_out IS NOT NULL THEN s.tokens_bought / pow(
+        10,
+        decimals_out
+      )
+      ELSE s.tokens_bought
+    END AS amount_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__curve_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON c1.address = s.token_in
+    LEFT JOIN contracts c2
+    ON c2.address = s.token_out
+  WHERE
+    amount_out <> 0
+    AND COALESCE(
+      token_symbol_in,
+      'null'
+    ) <> COALESCE(token_symbol_out, 'null')
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+  SELECT
+    MAX(_inserted_timestamp) :: DATE - 1
+  FROM
+    {{ this }}
+)
+{% endif %}
+),
+balancer_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    NULL AS pool_name,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__balancer_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+honeyswap_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    NULL AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__honeyswap_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+swapr_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    NULL AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__swapr_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+--union all standard dex CTEs here (excludes amount_usd)
+all_dex_standard AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    balancer_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    sushi_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    token_symbol_in AS symbol_in,
+    token_symbol_out AS symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    curve_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    honeyswap_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    swapr_swaps
+),
+FINAL AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_in,
+    CASE
+      WHEN s.decimals_in IS NOT NULL THEN ROUND(
+        amount_in * p1.price,
+        2
+      )
+      ELSE NULL
+    END AS amount_in_usd,
+    amount_out_unadj,
+    amount_out,
+    CASE
+      WHEN s.decimals_out IS NOT NULL THEN ROUND(
+        amount_out * p2.price,
+        2
+      )
+      ELSE NULL
+    END AS amount_out_usd,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    all_dex_standard s
+    LEFT JOIN prices p1
+    ON s.token_in = p1.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p1.hour
+    LEFT JOIN prices p2
+    ON s.token_out = p2.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p2.hour
+)
+SELECT
+  f.block_number,
+  f.block_timestamp,
+  f.tx_hash,
+  origin_function_signature,
+  origin_from_address,
+  origin_to_address,
+  f.contract_address,
+  CASE
+    WHEN f.pool_name IS NULL THEN p.pool_name
+    ELSE f.pool_name
+  END AS pool_name,
+  event_name,
+  amount_in_unadj,
+  amount_in,
+  CASE
+    WHEN amount_out_usd IS NULL
+    OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_out_usd, 0)) > 0.75
+    OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_in_usd, 0)) > 0.75 THEN NULL
+    ELSE amount_in_usd
+  END AS amount_in_usd,
+  amount_out_unadj,
+  amount_out,
+  CASE
+    WHEN amount_in_usd IS NULL
+    OR ABS((amount_out_usd - amount_in_usd) / NULLIF(amount_in_usd, 0)) > 0.75
+    OR ABS((amount_out_usd - amount_in_usd) / NULLIF(amount_out_usd, 0)) > 0.75 THEN NULL
+    ELSE amount_out_usd
+  END AS amount_out_usd,
+  sender,
+  tx_to,
+  event_index,
+  f.platform,
+  token_in,
+  token_out,
+  symbol_in,
+  symbol_out,
+  f._log_id,
+  f._inserted_timestamp
+FROM
+  FINAL f
+LEFT JOIN {{ ref('silver_dex__complete_dex_liquidity_pools') }} p
+  ON f.contract_address = p.pool_address

--- a/models/silver/dex/silver_dex__complete_dex_swaps.yml
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.yml
@@ -1,0 +1,129 @@
+version: 2
+models:
+  - name: silver_dex__complete_dex_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_NAME
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+          - not_null
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN_USD
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_USD
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null:
+              where: PLATFORM <> 'curve'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null:
+              where: PLATFORM <> 'curve'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SENDER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+              enabled: False
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.sql
@@ -1,0 +1,58 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address",
+    tags = ['non_realtime']
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        ethereum.public.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) :: INT AS pool_id,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs') }}
+    WHERE
+        contract_address = LOWER('0xc35DADB65012eC5796536bD9864eD8773aBc74C4')
+        AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    contract_address,
+    token0,
+    token1,
+    pool_address,
+    pool_id,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.yml
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__sushi_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+                - TIMESTAMP_LTZ

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -1,0 +1,117 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['non_realtime']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__sushi_pools') }}
+),
+swaps_base AS (
+    SELECT
+        block_number,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            ) :: INTEGER
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            ) :: INTEGER
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            ) :: INTEGER
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [3] :: STRING
+            ) :: INTEGER
+        ) AS amount1Out,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tx_to,
+        token0,
+        token1,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }}
+        INNER JOIN pools p
+        ON p.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    contract_address,
+    sender,
+    tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Swap' AS event_name,
+    'sushiswap' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.yml
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: silver_dex__sushi_swaps
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+                - TIMESTAMP_LTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+

--- a/models/silver/dex/swapr/silver_dex__swapr_pools.sql
+++ b/models/silver/dex/swapr/silver_dex__swapr_pools.sql
@@ -1,0 +1,58 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address",
+    tags = ['non_realtime']
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        ethereum.public.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) :: INT AS pool_id,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs') }}
+    WHERE
+        contract_address = LOWER('0x5D48C95AdfFD4B40c1AAADc4e08fc44117E02179')
+        AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    contract_address,
+    token0,
+    token1,
+    pool_address,
+    pool_id,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/swapr/silver_dex__swapr_pools.yml
+++ b/models/silver/dex/swapr/silver_dex__swapr_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__swapr_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+                - TIMESTAMP_LTZ

--- a/models/silver/dex/swapr/silver_dex__swapr_swaps.sql
+++ b/models/silver/dex/swapr/silver_dex__swapr_swaps.sql
@@ -1,0 +1,117 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['non_realtime']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__swapr_pools') }}
+),
+swaps_base AS (
+    SELECT
+        block_number,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            ) :: INTEGER
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            ) :: INTEGER
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            ) :: INTEGER
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            PUBLIC.udf_hex_to_int(
+                segmented_data [3] :: STRING
+            ) :: INTEGER
+        ) AS amount1Out,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tx_to,
+        token0,
+        token1,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }}
+        INNER JOIN pools p
+        ON p.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    contract_address,
+    sender,
+    tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Swap' AS event_name,
+    'swapr' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/swapr/silver_dex__swapr_swaps.yml
+++ b/models/silver/dex/swapr/silver_dex__swapr_swaps.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: silver_dex__swapr_swaps
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+                - TIMESTAMP_LTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+


### PR DESCRIPTION
1. Adds 5 dexes, swaps and lps w/complete models and gold views
2. Updates docs accordingly
3. Requires `dbt run -m models/silver/dex+ --full-refresh` and grants for new schema