### PR TITLE
AN-3975/delete-insert-reorg

### DIFF
--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -49,5 +49,5 @@ jobs:
   
       - name: Execute block_reorg macro
         run: |
-          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}"
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && grep -E "SQL status|/* {" logs/dbt.log
         

--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -1,0 +1,53 @@
+name: dbt_run_operation_reorg
+run-name: dbt_run_operation_reorg
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at minute 40 every 8 hours (see https://crontab.guru)
+    - cron: '40 */8 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+
+      - name: List reorg models
+        id: list_models
+        run: |
+          reorg_model_list=$(dbt list --select tag:reorg --resource-type model | awk -F'.' '{print $NF}' | tr '\n' ',' | sed 's/,$//')
+          echo "::set-output name=model_list::$reorg_model_list"
+  
+      - name: Execute block_reorg macro
+        run: |
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}"
+        

--- a/models/gold/core/core__ez_xdai_transfers.sql
+++ b/models/gold/core/core__ez_xdai_transfers.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['core','non_realtime'],
     persist_docs ={ "relation": true,
     "columns": true }

--- a/models/gold/core/core__ez_xdai_transfers.sql
+++ b/models/gold/core/core__ez_xdai_transfers.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['core','non_realtime'],
+    tags = ['core','non_realtime','reorg'],
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -4,7 +4,9 @@
     unique_key = ['block_number', 'event_index'],
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     full_refresh = false,
     tags = ['decoded_logs']
 ) }}

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -4,11 +4,9 @@
     unique_key = ['block_number', 'event_index'],
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     full_refresh = false,
-    tags = ['decoded_logs']
+    tags = ['decoded_logs','reorg']
 ) }}
 
 WITH base_data AS (

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -2,6 +2,7 @@
     materialized = 'incremental',
     unique_key = '_log_id',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -2,8 +2,7 @@
     materialized = 'incremental',
     unique_key = '_log_id',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH logs AS (

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -1,10 +1,10 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    full_refresh = false
     tags = ['non_realtime']
 ) }}
-
---    full_refresh = false
 
 WITH pools_registered AS (
 
@@ -27,7 +27,7 @@ WITH pools_registered AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
-    full_refresh = false
+    full_refresh = false,
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -57,7 +59,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -1,9 +1,10 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    full_refresh = false,
     tags = ['non_realtime']
 ) }}
---    full_refresh = false,
 
 WITH contract_deployments AS (
 
@@ -31,7 +32,7 @@ WHERE
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 3
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "_log_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -72,7 +74,7 @@ curve_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -119,7 +121,7 @@ token_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pool_meta AS (

--- a/models/silver/dex/honeyswap/silver_dex__honeyswap_pools.sql
+++ b/models/silver/dex/honeyswap/silver_dex__honeyswap_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/honeyswap/silver_dex__honeyswap_swaps.sql
+++ b/models/silver/dex/honeyswap/silver_dex__honeyswap_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/honeyswap/silver_dex__honeyswap_swaps.sql
+++ b/models/silver/dex/honeyswap/silver_dex__honeyswap_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -62,7 +64,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-  tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -1,7 +1,9 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = "_id",
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
+  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
   tags = ['non_realtime']
 ) }}
 
@@ -26,6 +28,7 @@ SELECT
     pool_address,
     pool_name,
     'balancer' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp,
     token0,
@@ -42,7 +45,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -59,6 +62,7 @@ SELECT
     pool_address,
     pool_name,
     'curve' AS platform,
+    'v1' AS version,
     _call_id AS _id,
     _inserted_timestamp,
     MAX(CASE WHEN token_num = 1 THEN token_address END) AS token0,
@@ -75,7 +79,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -95,6 +99,7 @@ SELECT
     token0,
     token1,
     'honeyswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -103,7 +108,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -122,6 +127,7 @@ SELECT
     token0,
     token1,
     'swapr' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -130,7 +136,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -149,6 +155,7 @@ SELECT
     token0,
     token1,
     'sushiswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -157,7 +164,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -203,6 +210,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_standard p 
@@ -235,6 +243,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0', c0.symbol, 'token1', c1.symbol, 'token2', c2.symbol, 'token3', c3.symbol, 'token4', c4.symbol, 'token5', c5.symbol, 'token6', c6.symbol, 'token7', c7.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0', c0.decimals, 'token1', c1.decimals, 'token2', c2.decimals, 'token3', c3.decimals, 'token4', c4.decimals, 'token5', c5.decimals, 'token6', c6.decimals, 'token7', c7.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_other p
@@ -261,6 +270,7 @@ SELECT
     block_timestamp,
     tx_hash,
     platform,
+    version,
     contract_address,
     pool_address,
     pool_name,

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-  tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -62,7 +64,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/swapr/silver_dex__swapr_pools.sql
+++ b/models/silver/dex/swapr/silver_dex__swapr_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/swapr/silver_dex__swapr_swaps.sql
+++ b/models/silver/dex/swapr/silver_dex__swapr_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/swapr/silver_dex__swapr_swaps.sql
+++ b/models/silver/dex/swapr/silver_dex__swapr_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -62,7 +64,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -3,10 +3,8 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
-    tags = ['non_realtime']
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base AS (

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -1,9 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    merge_update_columns = ["_log_id"],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -30,7 +30,7 @@ AND p._inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.6.0
+    revision: v1.6.1
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.5.0
+    revision: v1.6.0
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
1. Changes incremental strategy to delete+insert on `block_number` in majority of logs based downstream models
2. Minimizes incremental lookback to rolling 12-24 hrs vs 1-3 days, with exceptions
3. FR required on complete_dex_swaps, complete_dex_liquidity_pools to add `version` columns
4. Adds new workflow for block reorg macro, scheduled to run 3x daily - based on `reorg` tag