### PR TITLE
export columns

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -51,6 +51,7 @@ query-comment:
 
 models:
   +copy_grants: true
+  +on_schema_change: "append_new_columns"
 
 # In this example config, we tell dbt to build all models in the example/ directory
 # as tables. These settings can be overridden in the individual model files

--- a/models/doc_descriptions/general/deprecation.md
+++ b/models/doc_descriptions/general/deprecation.md
@@ -1,11 +1,11 @@
 {% docs internal_column %}    
 
-Deprecated. This column is no longer used. Please remove from your query by Jan. 10 2024.
+Deprecated. This column is no longer used. Please remove from your query by Jan. 31 2024.
 
 {% enddocs %}
 
 {% docs amount_deprecation %}   
 
-This column is being deprecated for standardization purposes on Jan. 10 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `xdai_amount`.
+This column is being deprecated for standardization purposes on Jan. 31 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `xdai_amount`.
 
 {% enddocs %}

--- a/models/doc_descriptions/general/deprecation.md
+++ b/models/doc_descriptions/general/deprecation.md
@@ -1,12 +1,11 @@
-{% docs deprecation %}
+{% docs internal_column %}    
 
-Deprecating soon: This is a notice that we're only removing the below columns. Please migrate queries using these columns to `fact_decoded_event_logs`, `ez_decoded_event_logs` or use manual parsing of topics and data. The following columns will be deprecated on 8/28/23:
+Deprecated. This column is no longer used. Please remove from your query by Jan. 10 2024.
 
-`Fact_event_logs` Columns:
-- `event_name`
-- `event_inputs`
-- `contract_name`
+{% enddocs %}
 
-`Fact_transactions` Columns:
-- `tx_json`
+{% docs amount_deprecation %}   
+
+This column is being deprecated for standardization purposes on Jan. 10 2024. Please use the equivalent column without the native asset prefix. For example, use `amount` instead of `xdai_amount`.
+
 {% enddocs %}

--- a/models/doc_descriptions/general/export_columns.md
+++ b/models/doc_descriptions/general/export_columns.md
@@ -1,0 +1,17 @@
+{% docs pk %}
+
+The unique identifier for each row in the table.
+
+{% enddocs %}
+
+{% docs inserted_timestamp %}
+
+The utc timestamp at which the row was inserted into the table.
+
+{% enddocs %}
+
+{% docs modified_timestamp %}
+
+The utc timestamp at which the row was last modified.
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_event_index.md
+++ b/models/doc_descriptions/nft/nft_event_index.md
@@ -1,0 +1,5 @@
+{% docs nft_event_index %}
+
+The event number within a transaction 
+
+{% enddocs %}

--- a/models/doc_descriptions/nft/nft_intra_event_index.md
+++ b/models/doc_descriptions/nft/nft_intra_event_index.md
@@ -1,0 +1,5 @@
+{% docs nft_intra_event_index %}
+
+The order of events within a single event index. This is primarily used for ERC1155 NFT batch transfer events. 
+
+{% enddocs %}

--- a/models/doc_descriptions/traces/gno_traces_index.md
+++ b/models/doc_descriptions/traces/gno_traces_index.md
@@ -1,0 +1,5 @@
+{% docs gno_trace_index %}
+
+The index of the trace within the transaction.
+
+{% enddocs %}

--- a/models/gold/core/core__dim_contracts.sql
+++ b/models/gold/core/core__dim_contracts.sql
@@ -5,9 +5,29 @@
 ) }}
 
 SELECT
-    contract_address AS address,
-    token_symbol AS symbol,
-    token_name AS NAME,
-    token_decimals AS decimals
+    c0.created_contract_address AS address,
+    c1.token_symbol AS symbol,
+    c1.token_name AS NAME,
+    c1.token_decimals AS decimals,
+    c0.block_number AS created_block_number,
+    c0.block_timestamp AS created_block_timestamp,
+    c0.tx_hash AS created_tx_hash,
+    c0.creator_address AS creator_address,
+    COALESCE (
+        c0.created_contracts_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['c0.created_contract_address']
+        ) }}
+    ) AS dim_contracts_id,
+    GREATEST(COALESCE(c0.inserted_timestamp, '2000-01-01'), COALESCE(c1.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
+    GREATEST(COALESCE(c0.modified_timestamp, '2000-01-01'), COALESCE(c1.modified_timestamp, '2000-01-01')) AS modified_timestamp
 FROM
-    {{ ref('silver__contracts') }}
+    {{ ref('silver__created_contracts') }}
+    c0
+    LEFT JOIN {{ ref('silver__contracts') }}
+    c1
+    ON LOWER(
+        c0.created_contract_address
+    ) = LOWER(
+        c1.contract_address
+    )

--- a/models/gold/core/core__dim_contracts.yml
+++ b/models/gold/core/core__dim_contracts.yml
@@ -1,8 +1,8 @@
 version: 2
 models:
   - name: core__dim_contracts
-    description: 'This table contains the contract addresses and their associated metadata. Includes ERC20 and ERC721 tokens. Metadata is read directly from contracts on the blockchain.'
-
+    description: This table contains all the contracts that are deployed on the Gnosis blockchain along with their on-chain metadata.
+    
     columns:
       - name: ADDRESS
         description: 'The address of the contract.'
@@ -12,3 +12,17 @@ models:
         description: 'The name of the contract.'
       - name: DECIMALS
         description: 'The number of decimals used to adjust amount for this contract.'
+      - name: CREATED_BLOCK_NUMBER
+        description: 'The block number when the contract was created'
+      - name: CREATED_BLOCK_TIMESTAMP
+        description: 'The block timestamp when the contract was created'
+      - name: CREATED_TX_HASH
+        description: 'The transaction hash when the contract was created'
+      - name: CREATOR_ADDRESS
+        description: 'The address of the creator of the contract'
+      - name: DIM_CONTRACTS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  

--- a/models/gold/core/core__dim_labels.sql
+++ b/models/gold/core/core__dim_labels.sql
@@ -11,6 +11,20 @@ SELECT
     address_name,
     label_type,
     label_subtype,
-    project_name
+    project_name,
+    COALESCE (
+        labels_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['address']
+        ) }}
+    ) AS dim_labels_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__labels') }}

--- a/models/gold/core/core__dim_labels.yml
+++ b/models/gold/core/core__dim_labels.yml
@@ -52,4 +52,9 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
-
+      - name: DIM_LABELS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'  

--- a/models/gold/core/core__ez_decoded_event_logs.sql
+++ b/models/gold/core/core__ez_decoded_event_logs.sql
@@ -20,7 +20,16 @@ SELECT
     topics,
     DATA,
     event_removed,
-    tx_status
+    tx_status,
+    COALESCE (
+        decoded_logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS ez_decoded_event_logs_id,
+    GREATEST(COALESCE(l.inserted_timestamp, '2000-01-01'), COALESCE(C.inserted_timestamp, '2000-01-01')) AS inserted_timestamp,
+    GREATEST(COALESCE(l.modified_timestamp, '2000-01-01'), COALESCE(C.modified_timestamp, '2000-01-01')) AS modified_timestamp
 FROM
-    {{ ref('silver__decoded_logs') }} 
-    LEFT JOIN {{ ref('silver__contracts') }} USING (contract_address)
+    {{ ref('silver__decoded_logs') }}
+    l
+    LEFT JOIN {{ ref('silver__contracts') }} C USING (contract_address)

--- a/models/gold/core/core__ez_decoded_event_logs.yml
+++ b/models/gold/core/core__ez_decoded_event_logs.yml
@@ -57,3 +57,9 @@ models:
         description: '{{ doc("gno_event_removed") }}' 
       - name: TX_STATUS
         description: '{{ doc("gno_tx_status") }}' 
+      - name: EZ_DECODED_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__ez_native_transfers.sql
+++ b/models/gold/core/core__ez_native_transfers.sql
@@ -5,34 +5,27 @@
 ) }}
 
 SELECT
+    tx_hash,
     block_number,
     block_timestamp,
-    tx_hash,
-    event_index,
-    origin_function_signature,
+    tx_position,
+    trace_index,
+    identifier,
     origin_from_address,
     origin_to_address,
-    contract_address,
+    origin_function_signature,
     from_address,
     to_address,
-    raw_amount_precise,
-    raw_amount,
-    amount_precise,
     amount,
+    amount_precise_raw,
+    amount_precise,
     amount_usd,
-    decimals,
-    symbol,
-    token_price,
-    has_decimal,
-    has_price,
-    _log_id,
-    _inserted_timestamp,
     COALESCE (
-        transfers_id,
+        native_transfers_id,
         {{ dbt_utils.generate_surrogate_key(
-            ['tx_hash', 'event_index']
+            ['tx_hash', 'trace_index']
         ) }}
-    ) AS ez_token_transfers_id,
+    ) AS ez_native_transfers_id,
     COALESCE(
         inserted_timestamp,
         '2000-01-01'
@@ -42,4 +35,4 @@ SELECT
         '2000-01-01'
     ) AS modified_timestamp
 FROM
-    {{ ref('silver__transfers') }}
+    {{ ref('silver__native_transfers') }}

--- a/models/gold/core/core__ez_native_transfers.yml
+++ b/models/gold/core/core__ez_native_transfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: core__ez_native_transfers
-    description: '{{ doc("gno_ez_eth_transfers_table_doc") }}'
+    description: '{{ doc("gno_ez_xdai_transfers_table_doc") }}'
 
     columns:
       - name: TX_HASH
@@ -27,13 +27,13 @@ models:
       - name: TO_ADDRESS
         description: '{{ doc("gno_transfer_to_address") }}'
       - name: AMOUNT
-        description: '{{ doc("gno_eth_amount") }}'
+        description: '{{ doc("gno_xdai_amount") }}'
       - name: AMOUNT_PRECISE_RAW
         description: '{{ doc("precise_amount_unadjusted") }}'
       - name: AMOUNT_PRECISE
         description: '{{ doc("precise_amount_adjusted") }}'
       - name: AMOUNT_USD
-        description: '{{ doc("gno_eth_amount_usd") }}' 
+        description: '{{ doc("gno_xdai_amount_usd") }}' 
       - name: EZ_NATIVE_TRANSFERS_ID
         description: '{{ doc("pk") }}'   
       - name: INSERTED_TIMESTAMP

--- a/models/gold/core/core__ez_native_transfers.yml
+++ b/models/gold/core/core__ez_native_transfers.yml
@@ -1,0 +1,42 @@
+version: 2
+models:
+  - name: core__ez_native_transfers
+    description: '{{ doc("gno_ez_eth_transfers_table_doc") }}'
+
+    columns:
+      - name: TX_HASH
+        description: '{{ doc("gno_transfer_tx_hash") }}'
+      - name: BLOCK_NUMBER
+        description: '{{ doc("gno_block_number") }}'
+      - name: BLOCK_TIMESTAMP
+        description: '{{ doc("gno_block_timestamp") }}'
+      - name: TX_POSITION
+        description: '{{ doc("gno_tx_position") }}'
+      - name: TRACE_INDEX
+        description: '{{ doc("gno_trace_index") }}'
+      - name: IDENTIFIER
+        description: '{{ doc("gno_traces_identifier") }}'
+      - name: ORIGIN_FROM_ADDRESS
+        description: '{{ doc("gno_origin_from") }}'
+      - name: ORIGIN_TO_ADDRESS
+        description: '{{ doc("gno_origin_to") }}'
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        description: '{{ doc("gno_origin_sig") }}'
+      - name: FROM_ADDRESS
+        description: '{{ doc("gno_transfer_from_address") }}'
+      - name: TO_ADDRESS
+        description: '{{ doc("gno_transfer_to_address") }}'
+      - name: AMOUNT
+        description: '{{ doc("gno_eth_amount") }}'
+      - name: AMOUNT_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: AMOUNT_PRECISE
+        description: '{{ doc("precise_amount_adjusted") }}'
+      - name: AMOUNT_USD
+        description: '{{ doc("gno_eth_amount_usd") }}' 
+      - name: EZ_NATIVE_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/core/core__ez_token_transfers.yml
+++ b/models/gold/core/core__ez_token_transfers.yml
@@ -47,4 +47,12 @@ models:
       - name: HAS_PRICE
         description: '{{ doc("gno_transfer_has_price") }}'
       - name: _LOG_ID
-        description: '{{ doc("gno_log_id_transfers") }}'
+        description: '{{ doc("internal_column") }}'
+      - name: _INSERTED_TIMESTAMP
+        description: '{{ doc("internal_column") }}'
+      - name: EZ_TOKEN_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/core/core__ez_xdai_transfers.sql
+++ b/models/gold/core/core__ez_xdai_transfers.sql
@@ -1,118 +1,26 @@
 {{ config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = 'block_number',
-    cluster_by = ['block_timestamp::DATE'],
-    tags = ['core','non_realtime','reorg'],
+    materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}
 
-WITH xdai_base AS (
-
-    SELECT
-        tx_hash,
-        block_number,
-        block_timestamp,
-        identifier,
-        from_address,
-        to_address,
-        xdai_value,
-        _call_id,
-        _inserted_timestamp,
-        to_varchar(
-            TO_NUMBER(REPLACE(DATA :value :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :value :: STRING, '0x'))))
-        ) AS xdai_value_precise_raw,
-        IFF(LENGTH(xdai_value_precise_raw) > 18, LEFT(xdai_value_precise_raw, LENGTH(xdai_value_precise_raw) - 18) || '.' || RIGHT(xdai_value_precise_raw, 18), '0.' || LPAD(xdai_value_precise_raw, 18, '0')) AS rough_conversion,
-        IFF(
-            POSITION(
-                '.000000000000000000' IN rough_conversion
-            ) > 0,
-            LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
-            REGEXP_REPLACE(
-                rough_conversion,
-                '0*$',
-                ''
-            )
-        ) AS xdai_value_precise,
-        tx_position,
-        trace_index
-    FROM
-        {{ ref('silver__traces') }}
-    WHERE
-        xdai_value > 0
-        AND tx_status = 'SUCCESS'
-        AND trace_status = 'SUCCESS'
-        AND TYPE NOT IN (
-            'DELEGATECALL',
-            'STATICCALL'
-        )
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '72 hours'
-    FROM
-        {{ this }}
-)
-{% endif %}
-),
-tx_table AS (
-    SELECT
-        block_number,
-        tx_hash,
-        from_address AS origin_from_address,
-        to_address AS origin_to_address,
-        origin_function_signature
-    FROM
-        {{ ref('silver__transactions') }}
-    WHERE
-        tx_hash IN (
-            SELECT
-                DISTINCT tx_hash
-            FROM
-                xdai_base
-        )
-
-{% if is_incremental() %}
-AND _inserted_timestamp >= (
-    SELECT
-        MAX(_inserted_timestamp) - INTERVAL '72 hours'
-    FROM
-        {{ this }}
-)
-{% endif %}
-)
 SELECT
-    tx_hash AS tx_hash,
-    block_number AS block_number,
-    block_timestamp AS block_timestamp,
-    identifier AS identifier,
+    tx_hash,
+    block_number,
+    block_timestamp,
+    identifier,
     origin_from_address,
     origin_to_address,
     origin_function_signature,
     from_address AS xdai_from_address,
     to_address AS xdai_to_address,
-    xdai_value AS amount,
-    xdai_value_precise_raw AS amount_precise_raw,
-    xdai_value_precise AS amount_precise,
-    ROUND(
-        xdai_value * price,
-        2
-    ) AS amount_usd,
+    amount,
+    amount_precise_raw,
+    amount_precise,
+    amount_usd,
     _call_id,
     _inserted_timestamp,
     tx_position,
     trace_index
 FROM
-    xdai_base A
-    LEFT JOIN {{ ref('price__ez_hourly_token_prices') }}
-    ON DATE_TRUNC(
-        'hour',
-        A.block_timestamp
-    ) = HOUR
-    AND token_address = LOWER('0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d')
-    JOIN tx_table USING (
-        tx_hash,
-        block_number
-    )
+    {{ ref('silver__native_transfers') }}

--- a/models/gold/core/core__ez_xdai_transfers.yml
+++ b/models/gold/core/core__ez_xdai_transfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: core__ez_xdai_transfers
-    description: '{{ doc("gno_ez_xdai_transfers_table_doc") }}'
+    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 10 2024.'
       
     columns:
       - name: BLOCK_NUMBER

--- a/models/gold/core/core__ez_xdai_transfers.yml
+++ b/models/gold/core/core__ez_xdai_transfers.yml
@@ -1,7 +1,7 @@
 version: 2
 models:
   - name: core__ez_xdai_transfers
-    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 10 2024.'
+    description: 'Deprecating soon! Migrate to `core.ez_native_transfers` by Jan. 31 2024.'
       
     columns:
       - name: BLOCK_NUMBER

--- a/models/gold/core/core__fact_blocks.sql
+++ b/models/gold/core/core__fact_blocks.sql
@@ -61,7 +61,33 @@ SELECT
         transactions_root,
         'uncles',
         uncles
-    ) AS block_header_json
+    ) AS block_header_json,
+    COALESCE (
+        blocks_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['a.block_number']
+        ) }}
+    ) AS fact_blocks_id,
+    GREATEST(
+        COALESCE(
+            A.inserted_timestamp,
+            '2000-01-01'
+        ),
+        COALESCE(
+            d.inserted_timestamp,
+            '2000-01-01'
+        )
+    ) AS inserted_timestamp,
+    GREATEST(
+        COALESCE(
+            A.modified_timestamp,
+            '2000-01-01'
+        ),
+        COALESCE(
+            d.modified_timestamp,
+            '2000-01-01'
+        )
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__blocks') }} A
     LEFT JOIN {{ ref('silver__tx_count') }}

--- a/models/gold/core/core__fact_blocks.yml
+++ b/models/gold/core/core__fact_blocks.yml
@@ -40,3 +40,9 @@ models:
         description: '{{ doc("gno_block_header_json") }}'
       - name: MINER
         description: '{{ doc("gno_miner") }}'
+      - name: FACT_BLOCKS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/core/core__fact_decoded_event_logs.sql
+++ b/models/gold/core/core__fact_decoded_event_logs.sql
@@ -12,6 +12,20 @@ SELECT
     contract_address,
     event_name,
     decoded_flat AS decoded_log,
-    decoded_data AS full_decoded_log
+    decoded_data AS full_decoded_log,
+    COALESCE (
+        decoded_logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_decoded_event_logs_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__decoded_logs') }}

--- a/models/gold/core/core__fact_decoded_event_logs.yml
+++ b/models/gold/core/core__fact_decoded_event_logs.yml
@@ -41,3 +41,9 @@ models:
         description: 'The flattened decoded log, where the keys are the names of the event parameters, and the values are the values of the event parameters.'
       - name: FULL_DECODED_LOG
         description: 'The full decoded log, including the event name, the event parameters, and the data type of the event parameters.'  
+      - name: FACT_DECODED_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_event_logs.sql
+++ b/models/gold/core/core__fact_event_logs.sql
@@ -17,6 +17,20 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    _log_id
+    _log_id,
+    COALESCE (
+        logs_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_event_logs_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__logs') }}

--- a/models/gold/core/core__fact_event_logs.yml
+++ b/models/gold/core/core__fact_event_logs.yml
@@ -21,7 +21,7 @@ models:
       - name: EVENT_REMOVED
         description: '{{ doc("gno_event_removed") }}'  
       - name: _LOG_ID
-        description: '{{ doc("gno_log_id_events") }}'  
+        description: '{{ doc("internal_column") }}'  
       - name: TX_STATUS
         description: '{{ doc("gno_tx_status") }}' 
       - name: ORIGIN_FUNCTION_SIGNATURE
@@ -30,3 +30,9 @@ models:
         description: '{{ doc("gno_origin_from") }}'
       - name: ORIGIN_TO_ADDRESS
         description: '{{ doc("gno_origin_to") }}'
+      - name: FACT_EVENT_LOGS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_token_transfers.sql
+++ b/models/gold/core/core__fact_token_transfers.sql
@@ -17,6 +17,20 @@ SELECT
     to_address,
     raw_amount,
     raw_amount_precise,
-    _log_id
+    _log_id,
+    COALESCE (
+        transfers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }}
+    ) AS fact_token_transfers_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__transfers') }}

--- a/models/gold/core/core__fact_token_transfers.yml
+++ b/models/gold/core/core__fact_token_transfers.yml
@@ -29,4 +29,10 @@ models:
       - name: RAW_AMOUNT_PRECISE
         description: '{{ doc("gno_transfer_raw_amount_precise") }}'
       - name: _LOG_ID
-        description: '{{ doc("gno_log_id_transfers") }}'
+        description: '{{ doc("internal_column") }}'
+      - name: FACT_TOKEN_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/core/core__fact_traces.sql
+++ b/models/gold/core/core__fact_traces.sql
@@ -10,15 +10,15 @@ SELECT
     block_timestamp,
     from_address,
     to_address,
-    xdai_value,
+    xdai_value AS VALUE,
     IFNULL(
         xdai_value_precise_raw,
         '0'
-    ) AS xdai_value_precise_raw,
+    ) AS value_precise_raw,
     IFNULL(
         xdai_value_precise,
         '0'
-    ) AS xdai_value_precise,
+    ) AS value_precise,
     gas,
     gas_used,
     input,
@@ -30,7 +30,24 @@ SELECT
     sub_traces,
     trace_status,
     error_reason,
-    trace_index
+    trace_index,
+    COALESCE (
+        traces_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'trace_index']
+        ) }}
+    ) AS fact_traces_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp,
+    xdai_value,
+    xdai_value_precise_raw,
+    xdai_value_precise
 FROM
     (
         SELECT

--- a/models/gold/core/core__fact_traces.sql
+++ b/models/gold/core/core__fact_traces.sql
@@ -88,7 +88,10 @@ FROM
                     '0*$',
                     ''
                 )
-            ) AS xdai_value_precise
+            ) AS xdai_value_precise,
+            traces_id,
+            inserted_timestamp,
+            modified_timestamp
         FROM
             {{ ref('silver__traces') }}
     )

--- a/models/gold/core/core__fact_traces.yml
+++ b/models/gold/core/core__fact_traces.yml
@@ -15,10 +15,16 @@ models:
       - name: TO_ADDRESS
         description: '{{ doc("gno_traces_to") }}'
       - name: XDAI_VALUE
-        description: '{{ doc("gno_traces_value") }}'
+        description: '{{ doc("amount_deprecation") }}'
       - name: XDAI_VALUE_PRECISE_RAW
-        description: '{{ doc("precise_amount_unadjusted") }}'
+        description: '{{ doc("amount_deprecation") }}'
       - name: XDAI_VALUE_PRECISE
+        description: '{{ doc("amount_deprecation") }}'
+      - name: VALUE
+        description: '{{ doc("gno_traces_value") }}'
+      - name: VALUE_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: VALUE_PRECISE
         description: '{{ doc("precise_amount_adjusted") }}'
       - name: GAS
         description: '{{ doc("gno_traces_gas") }}'
@@ -44,7 +50,9 @@ models:
         description: The reason for the trace failure, if any.
       - name: TRACE_INDEX
         description: The index of the trace within the transaction. 
-
-
-
-        
+      - name: FACT_TRACES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -4,37 +4,7 @@
     "columns": true }
 ) }}
 
-
 SELECT
-block_number,
-    block_timestamp,
-    block_hash,
-    tx_hash,
-    nonce,
-    POSITION,
-    origin_function_signature,
-    from_address,
-    to_address,
-    xdai_value,
-    xdai_value_precise,
-    xdai_value_precise_raw,
-    tx_fee,
-    tx_fee_precise,
-    gas_price,
-    effective_gas_price,
-    gas_limit,
-    gas_used,
-    cumulative_gas_used,
-    max_fee_per_gas,
-    max_priority_fee_per_gas,
-    input_data,
-    status,
-    r,
-    s,
-    v,
-    tx_type    
-FROM
-(SELECT
     block_number,
     block_timestamp,
     block_hash,
@@ -44,7 +14,9 @@ FROM
     origin_function_signature,
     from_address,
     to_address,
-    VALUE AS xdai_value,
+    VALUE,
+    value_precise_raw,
+    value_precise,
     tx_fee,
     tx_fee_precise,
     gas_price,
@@ -60,21 +32,22 @@ FROM
     s,
     v,
     tx_type,
-    to_varchar(
-                TO_NUMBER(REPLACE(DATA :value :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :value :: STRING, '0x'))))
-            ) AS xdai_value_precise_raw,
-            IFF(LENGTH(xdai_value_precise_raw) > 18, LEFT(xdai_value_precise_raw, LENGTH(xdai_value_precise_raw) - 18) || '.' || RIGHT(xdai_value_precise_raw, 18), '0.' || LPAD(xdai_value_precise_raw, 18, '0')) AS rough_conversion,
-            IFF(
-                POSITION(
-                    '.000000000000000000' IN rough_conversion
-                ) > 0,
-                LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
-                REGEXP_REPLACE(
-                    rough_conversion,
-                    '0*$',
-                    ''
-                )
-        ) AS xdai_value_precise
+    COALESCE (
+        transactions_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash']
+        ) }}
+    ) AS fact_transactions_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp,
+    VALUE AS xdai_value,
+    value_precise_raw AS xdai_value_precise_raw,
+    value_precise AS xdai_value_precise
 FROM
     {{ ref('silver__transactions') }}
-)

--- a/models/gold/core/core__fact_transactions.yml
+++ b/models/gold/core/core__fact_transactions.yml
@@ -20,8 +20,18 @@ models:
         description: '{{ doc("gno_from_address") }}' 
       - name: TO_ADDRESS
         description: '{{ doc("gno_to_address") }}' 
-      - name: ETH_VALUE
+      - name: XDAI_VALUE
+        description: '{{ doc("amount_deprecation") }}'
+      - name: XDAI_VALUE_PRECISE_RAW
+        description: '{{ doc("amount_deprecation") }}'
+      - name: XDAI_VALUE_PRECISE
+        description: '{{ doc("amount_deprecation") }}'
+      - name: VALUE
         description: '{{ doc("gno_value") }}' 
+      - name: VALUE_PRECISE_RAW
+        description: '{{ doc("precise_amount_unadjusted") }}'
+      - name: VALUE_PRECISE
+        description: '{{ doc("precise_amount_adjusted") }}'
       - name: TX_FEE
         description: '{{ doc("gno_tx_fee") }}' 
       - name: TX_FEE_PRECISE
@@ -54,3 +64,9 @@ models:
         description: The v value of the transaction signature.
       - name: TX_TYPE
         description: The type of the transaction, 2 for EIP-1559 transactions and 0 for legacy transactions.
+      - name: FACT_TRANSACTIONS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.sql
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.sql
@@ -22,6 +22,20 @@ SELECT
     pool_name,
     tokens,
     symbols,
-    decimals
+    decimals,
+    COALESCE (
+        complete_dex_liquidity_pools_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['block_number','platform','version']
+        ) }}
+    ) AS dim_dex_liquidity_pools_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver_dex__complete_dex_liquidity_pools') }}

--- a/models/gold/defi/defi__dim_dex_liquidity_pools.yml
+++ b/models/gold/defi/defi__dim_dex_liquidity_pools.yml
@@ -24,3 +24,9 @@ models:
         description: '{{ doc("eth_dex_lp_symbols") }}'
       - name: DECIMALS
         description: '{{ doc("eth_dex_lp_decimals") }}'
+      - name: DIM_DEX_LIQUIDITY_POOLS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/defi/defi__ez_dex_swaps.sql
+++ b/models/gold/defi/defi__ez_dex_swaps.sql
@@ -36,5 +36,19 @@ SELECT
   token_out,
   symbol_in,
   symbol_out,
-  _log_id
+  _log_id,
+    COALESCE (
+        complete_dex_swaps_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash','event_index']
+        ) }}
+    ) AS ez_dex_swaps_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM {{ ref('silver_dex__complete_dex_swaps') }}

--- a/models/gold/defi/defi__ez_dex_swaps.yml
+++ b/models/gold/defi/defi__ez_dex_swaps.yml
@@ -39,7 +39,7 @@ models:
       - name: EVENT_INDEX
         description: '{{ doc("gno_event_index") }}'
       - name: _LOG_ID
-        description: '{{ doc("gno_log_id_events") }}'
+        description: '{{ doc("internal_column") }}'
       - name: ORIGIN_FUNCTION_SIGNATURE
         description: '{{ doc("gno_tx_origin_sig") }}'
       - name: ORIGIN_FROM_ADDRESS
@@ -50,5 +50,10 @@ models:
         description: '{{ doc("eth_dex_swaps_amount_in_unadj") }}'
       - name: AMOUNT_OUT_UNADJ
         description: '{{ doc("eth_dex_swaps_amount_out_unadj") }}'
-
+      - name: EZ_DEX_SWAPS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 
 

--- a/models/gold/nft/nft__ez_nft_transfers.sql
+++ b/models/gold/nft/nft__ez_nft_transfers.sql
@@ -2,7 +2,7 @@
     materialized = 'view',
     persist_docs ={ "relation": true,
     "columns": true },
-    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' } } }
+    meta ={ 'database_tags':{ 'table':{ 'PURPOSE': 'NFT' }} }
 ) }}
 
 SELECT
@@ -10,12 +10,27 @@ SELECT
     block_number,
     tx_hash,
     event_index,
+    intra_event_index,
     event_type,
     contract_address AS nft_address,
     project_name,
     from_address AS nft_from_address,
     to_address AS nft_to_address,
     tokenId,
-    erc1155_value
+    erc1155_value,
+    COALESCE (
+        nft_transfers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash','event_index','intra_event_index']
+        ) }}
+    ) AS ez_nft_transfers_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__nft_transfers') }}

--- a/models/gold/nft/nft__ez_nft_transfers.yml
+++ b/models/gold/nft/nft__ez_nft_transfers.yml
@@ -21,9 +21,9 @@ models:
       - name: PROJECT_NAME
         description: '{{ doc("nft_project_name") }}'
       - name: NFT_FROM_ADDRESS
-        description: '{{ doc("nft_nft_from_address") }}'
+        description: '{{ doc("nft_from_address") }}'
       - name: NFT_TO_ADDRESS
-        description: '{{ doc("nft_nft_to_address") }}'
+        description: '{{ doc("nft_to_address") }}'
       - name: TOKENID
         description: '{{ doc("nft_tokenid") }}'
       - name: ERC1155_VALUE

--- a/models/gold/nft/nft__ez_nft_transfers.yml
+++ b/models/gold/nft/nft__ez_nft_transfers.yml
@@ -10,57 +10,27 @@ models:
         description: '{{ doc("nft_blocktime") }}'
       - name: TX_HASH
         description: '{{ doc("nft_tx_hash") }}'
+      - name: EVENT_INDEX
+        description: '{{ doc("nft_event_index") }}'
+      - name: INTRA_EVENT_INDEX
+        description: '{{ doc("nft_intra_event_index") }}'
       - name: EVENT_TYPE
         description: '{{ doc("nft_event_type") }}'
-      - name: PLATFORM_ADDRESS
-        description: '{{ doc("nft_platform_address") }}'
-      - name: PLATFORM_NAME
-        description: '{{ doc("nft_platform_name") }}'
-      - name: PLATFORM_EXCHANGE_VERSION
-        description: '{{ doc("nft_platform_exchange_version") }}'
-      - name: AGGREGATOR_NAME
-        description: '{{ doc("nft_aggregator_name") }}'
-      - name: SELLER_ADDRESS
-        description: '{{ doc("nft_seller_address") }}'
-      - name: BUYER_ADDRESS
-        description: '{{ doc("nft_buyer_address") }}'
       - name: NFT_ADDRESS
         description: '{{ doc("nft_nft_address") }}'
       - name: PROJECT_NAME
         description: '{{ doc("nft_project_name") }}'
-      - name: ERC1155_VALUE
-        description: '{{ doc("nft_erc1155_value") }}'
+      - name: NFT_FROM_ADDRESS
+        description: '{{ doc("nft_nft_from_address") }}'
+      - name: NFT_TO_ADDRESS
+        description: '{{ doc("nft_nft_to_address") }}'
       - name: TOKENID
         description: '{{ doc("nft_tokenid") }}'
-      - name: TOKEN_METADATA
-        description: '{{ doc("nft_metadata") }}'
-      - name: CURRENCY_SYMBOL
-        description: '{{ doc("nft_currency_symbol") }}'
-      - name: CURRENCY_ADDRESS
-        description: '{{ doc("nft_currency_address") }}'
-      - name: PRICE
-        description: '{{ doc("nft_price") }}'
-      - name: PRICE_USD
-        description: '{{ doc("nft_price_usd") }}'
-      - name: TOTAL_FEES
-        description: '{{ doc("nft_total_fees") }}'
-      - name: PLATFORM_FEE
-        description: '{{ doc("nft_platform_fee") }}'
-      - name: CREATOR_FEE
-        description: '{{ doc("nft_creator_fee") }}'
-      - name: TOTAL_FEES_USD
-        description: '{{ doc("nft_total_fees_usd") }}'
-      - name: PLATFORM_FEE_USD
-        description: '{{ doc("nft_platform_fee_usd") }}'
-      - name: CREATOR_FEE_USD
-        description: '{{ doc("nft_creator_fee_usd") }}'
-      - name: TX_FEE
-        description: '{{ doc("nft_tx_fee") }}'
-      - name: TX_FEE_USD
-        description: '{{ doc("nft_tx_fee_usd") }}'
-      - name: ORIGIN_FROM_ADDRESS
-        description: '{{ doc("nft_origin_from") }}'
-      - name: ORIGIN_TO_ADDRESS
-        description: '{{ doc("nft_origin_to") }}'
-      - name: ORIGIN_FUNCTION_SIGNATURE
-        description: '{{ doc("nft_origin_sig") }}'
+      - name: ERC1155_VALUE
+        description: '{{ doc("nft_erc1155_value") }}'
+      - name: EZ_NFT_TRANSFERS_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/prices/price__dim_asset_metadata.sql
+++ b/models/gold/prices/price__dim_asset_metadata.sql
@@ -10,6 +10,20 @@ SELECT
     symbol,
     NAME,
     decimals,
-    provider
+    provider,
+    COALESCE (
+        asset_metadata_all_providers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address','symbol','id','provider']
+        ) }}
+    ) AS dim_asset_metadata_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__asset_metadata_all_providers') }}

--- a/models/gold/prices/price__dim_asset_metadata.yml
+++ b/models/gold/prices/price__dim_asset_metadata.yml
@@ -23,3 +23,9 @@ models:
         description: The specific address representing the asset in a specific platform.
       - name: DECIMALS
         description: The number of decimal places the token needs adjusted where token values exist.
+      - name: DIM_ASSET_METADATA_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/prices/price__ez_asset_metadata.sql
+++ b/models/gold/prices/price__ez_asset_metadata.sql
@@ -9,6 +9,20 @@ SELECT
     id,
     symbol,
     NAME,
-    decimals
+    decimals,
+    COALESCE (
+        asset_metadata_priority_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address']
+        ) }}
+    ) AS ez_asset_metadata_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__asset_metadata_priority') }}

--- a/models/gold/prices/price__ez_asset_metadata.yml
+++ b/models/gold/prices/price__ez_asset_metadata.yml
@@ -18,3 +18,9 @@ models:
         description: The specific address representing the asset in a specific platform.
       - name: DECIMALS
         description: The number of decimal places the token needs adjusted where token values exist.
+      - name: EZ_ASSET_METADATA_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/gold/prices/price__ez_hourly_token_prices.sql
+++ b/models/gold/prices/price__ez_hourly_token_prices.sql
@@ -10,6 +10,20 @@ SELECT
     symbol,
     decimals,
     price,
-    is_imputed
+    is_imputed,
+    COALESCE (
+        hourly_prices_priority_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address', 'hour']
+        ) }}
+    ) AS ez_hourly_token_prices_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__hourly_prices_priority') }}

--- a/models/gold/prices/price__ez_hourly_token_prices.yml
+++ b/models/gold/prices/price__ez_hourly_token_prices.yml
@@ -21,3 +21,9 @@ models:
         description: Closing price of the recorded hour in USD
       - name: IS_IMPUTED
         description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+      - name: EZ_HOURLY_TOKEN_PRICES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}' 

--- a/models/gold/prices/price__fact_hourly_token_prices.sql
+++ b/models/gold/prices/price__fact_hourly_token_prices.sql
@@ -9,6 +9,20 @@ SELECT
     token_address,
     price,
     is_imputed,
-    provider
+    provider,
+    COALESCE (
+        hourly_prices_all_providers_id,
+        {{ dbt_utils.generate_surrogate_key(
+            ['token_address', 'hour', 'provider']
+        ) }}
+    ) AS fact_hourly_token_prices_id,
+    COALESCE(
+        inserted_timestamp,
+        '2000-01-01'
+    ) AS inserted_timestamp,
+    COALESCE(
+        modified_timestamp,
+        '2000-01-01'
+    ) AS modified_timestamp
 FROM
     {{ ref('silver__hourly_prices_all_providers') }}

--- a/models/gold/prices/price__fact_hourly_token_prices.yml
+++ b/models/gold/prices/price__fact_hourly_token_prices.yml
@@ -14,3 +14,9 @@ models:
         description: Closing price of the recorded hour in USD
       - name: IS_IMPUTED
         description: Whether the price was imputed from an earlier record (generally used for low trade volume tokens)
+      - name: FACT_HOURLY_TOKEN_PRICES_ID
+        description: '{{ doc("pk") }}'   
+      - name: INSERTED_TIMESTAMP
+        description: '{{ doc("inserted_timestamp") }}'   
+      - name: MODIFIED_TIMESTAMP
+        description: '{{ doc("modified_timestamp") }}'

--- a/models/silver/core/silver__blocks.sql
+++ b/models/silver/core/silver__blocks.sql
@@ -4,49 +4,72 @@
     unique_key = "block_number",
     cluster_by = "block_timestamp::date",
     tags = ['non_realtime'],
+    merge_exclude_columns = ["inserted_timestamp"],
     full_refresh = false
 ) }}
 
 SELECT
     block_number,
-    TRY_TO_NUMBER(utils.udf_hex_to_int(
-        DATA :baseFeePerGas :: STRING
-    )) AS base_fee_per_gas,
-    TRY_TO_NUMBER(utils.udf_hex_to_int(
-        DATA :difficulty :: STRING
-    )) AS difficulty,
+    TRY_TO_NUMBER(
+        utils.udf_hex_to_int(
+            DATA :baseFeePerGas :: STRING
+        )
+    ) AS base_fee_per_gas,
+    TRY_TO_NUMBER(
+        utils.udf_hex_to_int(
+            DATA :difficulty :: STRING
+        )
+    ) AS difficulty,
     DATA :extraData :: STRING AS extra_data,
-    TRY_TO_NUMBER(utils.udf_hex_to_int(
-        DATA :gasLimit :: STRING
-    )) AS gas_limit,
-    TRY_TO_NUMBER(utils.udf_hex_to_int(
-        DATA :gasUsed :: STRING
-    )) AS gas_used,
+    TRY_TO_NUMBER(
+        utils.udf_hex_to_int(
+            DATA :gasLimit :: STRING
+        )
+    ) AS gas_limit,
+    TRY_TO_NUMBER(
+        utils.udf_hex_to_int(
+            DATA :gasUsed :: STRING
+        )
+    ) AS gas_used,
     DATA :hash :: STRING AS HASH,
     DATA :logsBloom :: STRING AS logs_bloom,
     DATA :miner :: STRING AS miner,
-    TRY_TO_NUMBER(utils.udf_hex_to_int(
-        DATA :nonce :: STRING
-    )) AS nonce,
-    TRY_TO_NUMBER(utils.udf_hex_to_int(
-        DATA :number :: STRING
-    )) AS NUMBER,
+    TRY_TO_NUMBER(
+        utils.udf_hex_to_int(
+            DATA :nonce :: STRING
+        )
+    ) AS nonce,
+    TRY_TO_NUMBER(
+        utils.udf_hex_to_int(
+            DATA :number :: STRING
+        )
+    ) AS NUMBER,
     DATA :parentHash :: STRING AS parent_hash,
     DATA :receiptsRoot :: STRING AS receipts_root,
     DATA :sha3Uncles :: STRING AS sha3_uncles,
-    TRY_TO_NUMBER(utils.udf_hex_to_int(
-        DATA :size :: STRING
-    )) AS SIZE,
+    TRY_TO_NUMBER(
+        utils.udf_hex_to_int(
+            DATA :size :: STRING
+        )
+    ) AS SIZE,
     DATA :stateRoot :: STRING AS state_root,
     utils.udf_hex_to_int(
         DATA :timestamp :: STRING
     ) :: TIMESTAMP AS block_timestamp,
-    TRY_TO_NUMBER(utils.udf_hex_to_int(
-        DATA :totalDifficulty :: STRING
-    )) AS total_difficulty,
+    TRY_TO_NUMBER(
+        utils.udf_hex_to_int(
+            DATA :totalDifficulty :: STRING
+        )
+    ) AS total_difficulty,
     DATA :transactionsRoot :: STRING AS transactions_root,
     DATA :uncles AS uncles,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_number']
+    ) }} AS blocks_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
 
 {% if is_incremental() %}

--- a/models/silver/core/silver__contracts.sql
+++ b/models/silver/core/silver__contracts.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'contract_address',
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -36,68 +37,75 @@ token_names AS (
         function_signature,
         read_output,
         utils.udf_hex_to_string(
-            SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_name
-    FROM
-        base_metadata
-    WHERE
-        function_signature = '0x06fdde03'
-        AND token_name IS NOT NULL
-),
-token_symbols AS (
-    SELECT
-        contract_address,
-        block_number,
-        function_signature,
-        read_output,
-        utils.udf_hex_to_string(
-            SUBSTR(read_output,(64*2+3),LEN(read_output))) AS token_symbol
-    FROM
-        base_metadata
-    WHERE
-        function_signature = '0x95d89b41'
-        AND token_symbol IS NOT NULL
-),
-token_decimals AS (
-    SELECT
-        contract_address,
-        CASE 
-            WHEN LENGTH(read_output :: STRING) <= 4300
-                THEN utils.udf_hex_to_int(
-                    read_output :: STRING
-                ) 
-            ELSE NULL 
-        END AS token_decimals,
-        LENGTH(token_decimals) AS dec_length
-    FROM
-        base_metadata
-    WHERE
-        function_signature = '0x313ce567'
-        AND read_output IS NOT NULL
-        AND read_output <> '0x'
-),
-contracts AS (
-    SELECT
-        contract_address,
-        MAX(_inserted_timestamp) AS _inserted_timestamp
-    FROM
-        base_metadata
-    GROUP BY
-        1
-)
-SELECT
-    c1.contract_address :: STRING AS contract_address,
-    token_name,
-    TRY_TO_NUMBER(token_decimals) AS token_decimals,
-    token_symbol,
-    _inserted_timestamp
-FROM
-    contracts c1
-    LEFT JOIN token_names
-    ON c1.contract_address = token_names.contract_address
-    LEFT JOIN token_symbols
-    ON c1.contract_address = token_symbols.contract_address
-    LEFT JOIN token_decimals
-    ON c1.contract_address = token_decimals.contract_address
-    AND dec_length < 3 qualify(ROW_NUMBER() over(PARTITION BY c1.contract_address
-ORDER BY
-    _inserted_timestamp DESC)) = 1
+            SUBSTR(read_output,(64 * 2 + 3), len(read_output))) AS token_name
+            FROM
+                base_metadata
+            WHERE
+                function_signature = '0x06fdde03'
+                AND token_name IS NOT NULL
+        ),
+        token_symbols AS (
+            SELECT
+                contract_address,
+                block_number,
+                function_signature,
+                read_output,
+                utils.udf_hex_to_string(
+                    SUBSTR(read_output,(64 * 2 + 3), len(read_output))) AS token_symbol
+                    FROM
+                        base_metadata
+                    WHERE
+                        function_signature = '0x95d89b41'
+                        AND token_symbol IS NOT NULL
+                ),
+                token_decimals AS (
+                    SELECT
+                        contract_address,
+                        CASE
+                            WHEN LENGTH(
+                                read_output :: STRING
+                            ) <= 4300 THEN utils.udf_hex_to_int(
+                                read_output :: STRING
+                            )
+                            ELSE NULL
+                        END AS token_decimals,
+                        LENGTH(token_decimals) AS dec_length
+                    FROM
+                        base_metadata
+                    WHERE
+                        function_signature = '0x313ce567'
+                        AND read_output IS NOT NULL
+                        AND read_output <> '0x'
+                ),
+                contracts AS (
+                    SELECT
+                        contract_address,
+                        MAX(_inserted_timestamp) AS _inserted_timestamp
+                    FROM
+                        base_metadata
+                    GROUP BY
+                        1
+                )
+            SELECT
+                c1.contract_address :: STRING AS contract_address,
+                token_name,
+                TRY_TO_NUMBER(token_decimals) AS token_decimals,
+                token_symbol,
+                _inserted_timestamp,
+                {{ dbt_utils.generate_surrogate_key(
+                    ['c1.contract_address']
+                ) }} AS contracts_id,
+                SYSDATE() AS inserted_timestamp,
+                SYSDATE() AS modified_timestamp,
+                '{{ invocation_id }}' AS _invocation_id
+            FROM
+                contracts c1
+                LEFT JOIN token_names
+                ON c1.contract_address = token_names.contract_address
+                LEFT JOIN token_symbols
+                ON c1.contract_address = token_symbols.contract_address
+                LEFT JOIN token_decimals
+                ON c1.contract_address = token_decimals.contract_address
+                AND dec_length < 3 qualify(ROW_NUMBER() over(PARTITION BY c1.contract_address
+            ORDER BY
+                _inserted_timestamp DESC)) = 1

--- a/models/silver/core/silver__created_contracts.sql
+++ b/models/silver/core/silver__created_contracts.sql
@@ -20,7 +20,6 @@ SELECT
     SYSDATE() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
 FROM
-FROM
     {{ ref('silver__traces') }}
 WHERE
     TYPE ILIKE 'create%'

--- a/models/silver/core/silver__created_contracts.sql
+++ b/models/silver/core/silver__created_contracts.sql
@@ -1,6 +1,7 @@
 {{ config (
     materialized = "incremental",
     unique_key = "created_contract_address",
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -11,7 +12,14 @@ SELECT
     to_address AS created_contract_address,
     from_address AS creator_address,
     input AS created_contract_input,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['to_address']
+    ) }} AS created_contracts_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
 FROM
     {{ ref('silver__traces') }}
 WHERE

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -6,6 +6,7 @@
     incremental_predicates = ["dynamic_range", "block_number"],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     full_refresh = false,
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['decoded_logs','reorg']
 ) }}
 
@@ -191,7 +192,13 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    is_pending
+    is_pending,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS decoded_logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     new_records
 
@@ -216,7 +223,13 @@ SELECT
     DATA,
     event_removed,
     tx_status,
-    is_pending
+    is_pending,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS decoded_logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     missing_data
 {% endif %}

--- a/models/silver/core/silver__logs.sql
+++ b/models/silver/core/silver__logs.sql
@@ -176,7 +176,13 @@ FROM
 {% endif %}
 )
 SELECT
-    *
+    *,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS logs_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL qualify(ROW_NUMBER() over (PARTITION BY block_number, event_index
 ORDER BY

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -16,11 +16,19 @@ WITH xdai_base AS (
         identifier,
         from_address,
         to_address,
-        xdai_value,
         _call_id,
         _inserted_timestamp,
-        xdai_value_precise_raw,
-        xdai_value_precise,
+        IFNULL(
+            utils.udf_hex_to_int(
+                DATA :value :: STRING
+            ),
+            '0'
+        ) AS xdai_value_precise_raw,
+        utils.udf_decimal_adjust(
+            xdai_value_precise_raw,
+            18
+        ) AS xdai_value_precise,
+        xdai_value_precise :: FLOAT AS xdai_value,
         tx_position,
         trace_index
     FROM

--- a/models/silver/core/silver__native_transfers.sql
+++ b/models/silver/core/silver__native_transfers.sql
@@ -1,0 +1,110 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    cluster_by = ['block_timestamp::DATE'],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    tags = ['core','non_realtime','reorg']
+) }}
+
+WITH xdai_base AS (
+
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        identifier,
+        from_address,
+        to_address,
+        xdai_value,
+        _call_id,
+        _inserted_timestamp,
+        xdai_value_precise_raw,
+        xdai_value_precise,
+        tx_position,
+        trace_index
+    FROM
+        {{ ref('silver__traces') }}
+    WHERE
+        xdai_value > 0
+        AND tx_status = 'SUCCESS'
+        AND trace_status = 'SUCCESS'
+        AND TYPE NOT IN (
+            'DELEGATECALL',
+            'STATICCALL'
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+tx_table AS (
+    SELECT
+        block_number,
+        tx_hash,
+        from_address AS origin_from_address,
+        to_address AS origin_to_address,
+        origin_function_signature
+    FROM
+        {{ ref('silver__transactions') }}
+    WHERE
+        tx_hash IN (
+            SELECT
+                DISTINCT tx_hash
+            FROM
+                xdai_base
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    tx_hash AS tx_hash,
+    block_number AS block_number,
+    block_timestamp AS block_timestamp,
+    identifier AS identifier,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    from_address,
+    to_address,
+    xdai_value AS amount,
+    xdai_value_precise_raw AS amount_precise_raw,
+    xdai_value_precise AS amount_precise,
+    ROUND(
+        xdai_value * price,
+        2
+    ) AS amount_usd,
+    _call_id,
+    _inserted_timestamp,
+    tx_position,
+    trace_index,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'trace_index']
+    ) }} AS native_transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    xdai_base A
+    LEFT JOIN {{ ref('price__ez_hourly_token_prices') }}
+    ON DATE_TRUNC(
+        'hour',
+        A.block_timestamp
+    ) = HOUR
+    AND token_address = LOWER('0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d')
+    JOIN tx_table USING (
+        tx_hash,
+        block_number
+    )

--- a/models/silver/core/silver__receipts.sql
+++ b/models/silver/core/silver__receipts.sql
@@ -45,10 +45,7 @@ FINAL AS (
         ) :: INT AS cumulative_gas_used,
         utils.udf_hex_to_int(
             DATA :effectiveGasPrice :: STRING
-        ) :: INT / pow(
-            10,
-            9
-        ) AS effective_gas_price,
+        ) :: bigint AS effective_gas_price,
         DATA :from :: STRING AS from_address,
         utils.udf_hex_to_int(
             DATA :gasUsed :: STRING

--- a/models/silver/core/silver__traces.sql
+++ b/models/silver/core/silver__traces.sql
@@ -381,7 +381,13 @@ SELECT
     DATA,
     is_pending,
     _call_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'trace_index']
+    ) }} AS traces_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL qualify(ROW_NUMBER() over(PARTITION BY block_number, tx_position, trace_index
 ORDER BY

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -5,8 +5,7 @@
     unique_key = "block_number",
     cluster_by = "block_timestamp::date, _inserted_timestamp::date",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-    tags = ['non_realtime'],
-    full_refresh = false
+    tags = ['non_realtime']
 ) }}
 
 WITH base AS (
@@ -329,7 +328,6 @@ FROM
 )
 SELECT
     *,
-    DATA,
     {{ dbt_utils.generate_surrogate_key(
         ['tx_hash']
     ) }} AS transactions_id,

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -89,7 +89,12 @@ base_tx AS (
         A.data :v :: STRING AS v,
         utils.udf_hex_to_int(
             A.data :value :: STRING
-        ) :: FLOAT AS VALUE,
+        ) AS value_precise_raw,
+        utils.udf_decimal_adjust(
+            value_precise_raw,
+            18
+        ) AS value_precise,
+        value_precise :: FLOAT AS VALUE,
         A._INSERTED_TIMESTAMP,
         A.data
     FROM
@@ -115,6 +120,8 @@ new_records AS (
         t.position,
         t.type,
         t.v,
+        t.value_precise_raw,
+        t.value_precise,
         t.value,
         block_timestamp,
         CASE
@@ -126,16 +133,21 @@ new_records AS (
         tx_success,
         tx_status,
         cumulative_gas_used,
-        effective_gas_price,
+        utils.udf_decimal_adjust(
+            r.effective_gas_price,
+            9
+        ) AS effective_gas_price,
         CASE
             WHEN t.block_number >= 19040000
             AND r.type = 2 THEN utils.udf_decimal_adjust(
-                effective_gas_price * r.gas_used,
-                9
+                r.effective_gas_price * r.gas_used,
+                18
             )
             ELSE utils.udf_decimal_adjust(
-                gas_price * r.gas_used,
-                9
+                utils.udf_hex_to_int(
+                    t.data :gasPrice :: STRING
+                ) :: bigint * r.gas_used,
+                18
             )
         END AS tx_fee_precise,
         COALESCE(
@@ -186,6 +198,8 @@ missing_data AS (
         t.position,
         t.type,
         t.v,
+        t.value_precise_raw,
+        t.value_precise,
         t.value,
         b.block_timestamp,
         FALSE AS is_pending,
@@ -193,16 +207,21 @@ missing_data AS (
         r.tx_success,
         r.tx_status,
         r.cumulative_gas_used,
-        r.effective_gas_price,
+        utils.udf_decimal_adjust(
+            r.effective_gas_price,
+            9
+        ) AS effective_gas_price,
         CASE
             WHEN t.block_number >= 19040000
             AND r.type = 2 THEN utils.udf_decimal_adjust(
                 r.effective_gas_price * r.gas_used,
-                9
+                18
             )
             ELSE utils.udf_decimal_adjust(
-                t.gas_price * r.gas_used,
-                9
+                utils.udf_hex_to_int(
+                    t.data :gasPrice :: STRING
+                ) :: bigint * r.gas_used,
+                18
             )
         END AS tx_fee_precise_heal,
         COALESCE(
@@ -250,6 +269,8 @@ FINAL AS (
         POSITION,
         TYPE,
         v,
+        value_precise_raw,
+        value_precise,
         VALUE,
         block_timestamp,
         is_pending,
@@ -287,6 +308,8 @@ SELECT
     POSITION,
     TYPE,
     v,
+    value_precise_raw,
+    value_precise,
     VALUE,
     block_timestamp,
     is_pending,
@@ -305,7 +328,14 @@ FROM
 {% endif %}
 )
 SELECT
-    *
+    *,
+    DATA,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash']
+    ) }} AS transactions_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     FINAL
 WHERE

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -239,7 +239,13 @@ heal_model AS (
         has_decimal,
         has_price,
         _log_id,
-        _inserted_timestamp
+        _inserted_timestamp,
+        {{ dbt_utils.generate_surrogate_key(
+            ['tx_hash', 'event_index']
+        ) }} AS transfers_id,
+        SYSDATE() AS inserted_timestamp,
+        SYSDATE() AS modified_timestamp,
+        '{{ invocation_id }}' AS _invocation_id
     FROM
         token_transfers
 
@@ -269,7 +275,13 @@ SELECT
     has_decimal,
     has_price,
     _log_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['tx_hash', 'event_index']
+    ) }} AS transfers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     heal_model
 {% endif %}

--- a/models/silver/core/silver__tx_count.sql
+++ b/models/silver/core/silver__tx_count.sql
@@ -1,15 +1,10 @@
-{{ config(
-    materialized = 'incremental',
-    unique_key = "block_number",
-    tags = ['non_realtime']
-) }}
-
-SELECT
-    block_number,
-    MIN(_inserted_timestamp) AS _inserted_timestamp,
-    COUNT(*) AS tx_count
-FROM
-    {{ ref('silver__transactions') }}
+WITH base AS (
+    SELECT
+        block_number,
+        MIN(_inserted_timestamp) AS _inserted_timestamp,
+        COUNT(*) AS tx_count
+    FROM
+        {{ ref('silver__transactions') }}
 
 {% if is_incremental() %}
 WHERE
@@ -22,3 +17,14 @@ WHERE
 {% endif %}
 GROUP BY
     block_number
+)
+SELECT
+    *,
+    {{ dbt_utils.generate_surrogate_key(
+        ['block_number']
+    ) }} AS tx_count_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    base

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -404,6 +404,12 @@ SELECT
   symbols,
   decimals,
   _id,
-  _inserted_timestamp
+  _inserted_timestamp,
+  {{ dbt_utils.generate_surrogate_key(
+    ['block_number','platform','version']
+  ) }} AS complete_dex_liquidity_pools_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
 FROM
   FINAL

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -554,7 +554,13 @@ SELECT
   symbol_in,
   symbol_out,
   f._log_id,
-  f._inserted_timestamp
+  f._inserted_timestamp,
+  {{ dbt_utils.generate_surrogate_key(
+    ['f.tx_hash','f.event_index']
+  ) }} AS complete_dex_swaps_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
 FROM
   FINAL f
   LEFT JOIN {{ ref('silver_dex__complete_dex_liquidity_pools') }}

--- a/models/silver/labels/silver__labels.sql
+++ b/models/silver/labels/silver__labels.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'address',
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -13,7 +14,13 @@ SELECT
     label_type,
     label_subtype,
     address_name,
-    project_name
+    project_name,
+    {{ dbt_utils.generate_surrogate_key(
+        ['address']
+    ) }} AS labels_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__labels') }}
 WHERE

--- a/models/silver/nft/silver__nft_transfers.yml
+++ b/models/silver/nft/silver__nft_transfers.yml
@@ -29,6 +29,12 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: INTRA_EVENT_INDEX
+        tests:
+          - not_null
       - name: CONTRACT_ADDRESS
         tests:
           - not_null

--- a/models/silver/prices/silver__asset_metadata_all_providers.sql
+++ b/models/silver/prices/silver__asset_metadata_all_providers.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    merge_exclude_columns = ["inserted_timestamp"],
     unique_key = ['token_address','symbol','id','provider'],
     tags = ['non_realtime']
 ) }}
@@ -14,7 +15,13 @@ SELECT
     token_name AS NAME,
     token_decimals AS decimals,
     provider,
-    p._inserted_timestamp
+    p._inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['token_address','symbol','id','provider']
+    ) }} AS asset_metadata_all_providers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__asset_metadata_all_providers') }}
     p

--- a/models/silver/prices/silver__hourly_prices_all_providers.sql
+++ b/models/silver/prices/silver__hourly_prices_all_providers.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['token_address', 'hour', 'provider'],
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -10,7 +11,13 @@ SELECT
     provider,
     price,
     is_imputed,
-    _inserted_timestamp
+    _inserted_timestamp,
+    {{ dbt_utils.generate_surrogate_key(
+        ['token_address', 'hour', 'provider']
+    ) }} AS hourly_prices_all_providers_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__hourly_prices_all_providers') }}
 WHERE

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = ['token_address', 'hour'],
+    merge_exclude_columns = ["inserted_timestamp"],
     tags = ['non_realtime']
 ) }}
 
@@ -14,7 +15,13 @@ SELECT
         C.token_symbol,
         m.symbol
     ) AS symbol,
-    c.token_decimals AS decimals
+    C.token_decimals AS decimals,
+    {{ dbt_utils.generate_surrogate_key(
+        ['p.token_address', 'p.hour']
+    ) }} AS hourly_prices_priority_id,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
 FROM
     {{ ref('bronze__hourly_prices_priority') }}
     p
@@ -25,6 +32,7 @@ FROM
     ON p.token_address = C.contract_address
 WHERE
     1 = 1
+
 {% if is_incremental() %}
 AND p._inserted_timestamp >= (
     SELECT


### PR DESCRIPTION
- adds export columns: `<pk>`, `inserted_timestamp`, and `modified_timestamp` to gold
- adds `_invocation_id` to silver
- creates `silver__native_transfers` to replace gold table logic, also builds `core.ez_native_transfers` to replace `core.ez_eth_transfers`
- adds generic columns to `fact_traces` and `fact_transactions`, deprecation notice on impacted columns
- adds deprecation notice to any internal columns, denoted with `_`. This is mostly just removing `_log_id` and `_inserted_timestamp` from gold to be consistent
- command 1: `dbt run -m models/silver/core/silver__native_transfers.sql models/silver/nft/silver__complete_nft_sales.sql models/silver/nft/silver__nft_transfers.sql models/silver/core/silver__transactions.sql models/silver/core/tests --full-refresh && dbt run -m models/silver models/gold`