### PR TITLE
add/gnosis-decoder-history

### DIFF
--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_029263079_029563079.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_029263079_029563079.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_029563080_029863080.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_029563080_029863080.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_029863081_030163081.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_029863081_030163081.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_030163082_030463082.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_030163082_030463082.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_030463083_030763083.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_030463083_030763083.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_030763084_031063084.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_030763084_031063084.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_031063085_031363085.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_031063085_031363085.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_031363086_031663086.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_031363086_031663086.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_031663087_031963087.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_031663087_031963087.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_031963088_032263088.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_031963088_032263088.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_032263089_032563089.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_032263089_032563089.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_032563090_032863090.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_032563090_032863090.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_032863091_033163091.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_032863091_033163091.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_033163092_033463092.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_033163092_033463092.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_033463093_033763093.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_033463093_033763093.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_033763094_034063094.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_033763094_034063094.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_034063095_034363095.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_034063095_034363095.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_034363096_034663096.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_034363096_034663096.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_034663097_034963097.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_034663097_034963097.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_034963098_035263098.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_034963098_035263098.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_035263099_035563099.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_035263099_035563099.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_035563100_035863100.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_035563100_035863100.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_035863101_036163101.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_035863101_036163101.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_036163102_036463102.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_036163102_036463102.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_036463103_036763103.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_036463103_036763103.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_036763104_037063104.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_036763104_037063104.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_037063105_037363105.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_037063105_037363105.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_037363106_037663106.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_037363106_037663106.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_037663107_037963107.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_037663107_037963107.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_037963108_038263108.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_037963108_038263108.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_038263109_038563109.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_038263109_038563109.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_038563110_038863110.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_038563110_038863110.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_038863111_039163111.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_038863111_039163111.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_039163112_039463112.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_039163112_039463112.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_039463113_039763113.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_039463113_039763113.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_039763114_040063114.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_039763114_040063114.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_040063115_040363115.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_040063115_040363115.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_040363116_040663116.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_040363116_040663116.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_040663117_040963117.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_040663117_040963117.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_040963118_041263118.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_040963118_041263118.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_041263119_041563119.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_041263119_041563119.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_041563120_041863120.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_041563120_041863120.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_041863121_042163121.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_041863121_042163121.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_042163122_042463122.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_042163122_042463122.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_042463123_042763123.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_042463123_042763123.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_042763124_043063124.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_042763124_043063124.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_043063125_043363125.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_043063125_043363125.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_043363126_043663126.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_043363126_043663126.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_043663127_043963127.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_043663127_043963127.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_043963128_044263128.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_043963128_044263128.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_044263129_044563129.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_044263129_044563129.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_044563130_044863130.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_044563130_044863130.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_044863131_045163131.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_044863131_045163131.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_045163132_045463132.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_045163132_045463132.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_045463133_045763133.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_045463133_045763133.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_045763134_046063134.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_045763134_046063134.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_046063135_046363135.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_046063135_046363135.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_046363136_046663136.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_046363136_046663136.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_046663137_046963137.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_046663137_046963137.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_046963138_047263138.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_046963138_047263138.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_047263139_047563139.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_047263139_047563139.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_047563140_047863140.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_047563140_047863140.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_047863141_048163141.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_047863141_048163141.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_048163142_048463142.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_048163142_048463142.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_048463143_048763143.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_048463143_048763143.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_048763144_049063144.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_048763144_049063144.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_049063145_049363145.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_049063145_049363145.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_049363146_049663146.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_049363146_049663146.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_049663147_049963147.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_049663147_049963147.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}


### PR DESCRIPTION
1. Requires `dbt run -m models/streamline/silver/decoder/history --full-refresh` + run history job